### PR TITLE
QT: refine "Overview" and "Send" related issues

### DIFF
--- a/src/mastercore.cpp
+++ b/src/mastercore.cpp
@@ -2714,7 +2714,7 @@ static int64_t selectCoins(const string &FromAddress, CCoinControl &coinControl,
   // if referenceamount is set it is needed to be accounted for here too
   if (0 < additional) n_max += additional;
 
-  LOCK(wallet->cs_wallet);
+  LOCK2(cs_main, wallet->cs_wallet);
 
     string sAddress = "";
 

--- a/src/qt/forms/overviewpage.ui
+++ b/src/qt/forms/overviewpage.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>664</width>
-    <height>440</height>
+    <height>447</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -406,21 +406,21 @@
                 </property>
                </widget>
               </item>
-              <item row="3" column="0" colspan="2">
+              <item row="4" column="0" colspan="2">
                <widget class="Line" name="addedLine">
                 <property name="orientation">
                  <enum>Qt::Horizontal</enum>
                 </property>
                </widget>
               </item>
-              <item row="4" column="0">
+              <item row="5" column="0">
                <widget class="QLabel" name="MSClabel_4">
                 <property name="text">
                  <string>Total:</string>
                 </property>
                </widget>
               </item>
-              <item row="4" column="1">
+              <item row="5" column="1">
                <widget class="QLabel" name="MSClabeltotal">
                 <property name="font">
                  <font>
@@ -444,6 +444,22 @@
                  <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
                 </property>
                </widget>
+              </item>
+              <item row="3" column="0">
+               <spacer name="verticalSpacer_5">
+                <property name="orientation">
+                 <enum>Qt::Vertical</enum>
+                </property>
+                <property name="sizeType">
+                 <enum>QSizePolicy::Fixed</enum>
+                </property>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>20</width>
+                  <height>3</height>
+                 </size>
+                </property>
+               </spacer>
               </item>
              </layout>
             </item>

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -281,11 +281,11 @@ void OverviewPage::setBalance(qint64 balance, qint64 unconfirmedBalance, qint64 
             balText += tokenLabel;
             ui->SPbal1->setText(balText.c_str());
         }
+        ui->SPname1->setVisible(true);
+        ui->SPbal1->setVisible(true);
     }
     else
     {
-        ui->SPname1->setText("N/A");
-        ui->SPbal1->setText("N/A");
         ui->SPname1->setVisible(false);
         ui->SPbal1->setVisible(false);
     }
@@ -302,11 +302,11 @@ void OverviewPage::setBalance(qint64 balance, qint64 unconfirmedBalance, qint64 
             balText += " SPT";
             ui->SPbal2->setText(balText.c_str());
         }
+        ui->SPname2->setVisible(true);
+        ui->SPbal2->setVisible(true);
     }
     else
     {
-        ui->SPname2->setText("N/A");
-        ui->SPbal2->setText("N/A");
         ui->SPname2->setVisible(false);
         ui->SPbal2->setVisible(false);
     }
@@ -323,11 +323,11 @@ void OverviewPage::setBalance(qint64 balance, qint64 unconfirmedBalance, qint64 
             balText += " SPT";
             ui->SPbal3->setText(balText.c_str());
         }
+        ui->SPname3->setVisible(true);
+        ui->SPbal3->setVisible(true);
     }
     else
     {
-        ui->SPname3->setText("N/A");
-        ui->SPbal3->setText("N/A");
         ui->SPname3->setVisible(false);
         ui->SPbal3->setVisible(false);
     }
@@ -344,11 +344,11 @@ void OverviewPage::setBalance(qint64 balance, qint64 unconfirmedBalance, qint64 
             balText += " SPT";
             ui->SPbal4->setText(balText.c_str());
         }
+        ui->SPname4->setVisible(true);
+        ui->SPbal4->setVisible(true);
     }
     else
     {
-        ui->SPname4->setText("N/A");
-        ui->SPbal4->setText("N/A");
         ui->SPname4->setVisible(false);
         ui->SPbal4->setVisible(false);
     }
@@ -365,11 +365,11 @@ void OverviewPage::setBalance(qint64 balance, qint64 unconfirmedBalance, qint64 
             balText += " SPT";
             ui->SPbal5->setText(balText.c_str());
         }
+        ui->SPname5->setVisible(true);
+        ui->SPbal5->setVisible(true);
     }
     else
     {
-        ui->SPname5->setText("N/A");
-        ui->SPbal5->setText("N/A");
         ui->SPname5->setVisible(false);
         ui->SPbal5->setVisible(false);
     }

--- a/src/qt/sendmpdialog.cpp
+++ b/src/qt/sendmpdialog.cpp
@@ -89,9 +89,7 @@ SendMPDialog::SendMPDialog(QWidget *parent) :
     connect(ui->sendButton, SIGNAL(clicked()), this, SLOT(sendButtonClicked()));
 
     // initial update
-    updatePropSelector();
-    updateProperty();
-    updateFrom();
+    balancesUpdated();
 }
 
 void SendMPDialog::setModel(WalletModel *model)
@@ -102,7 +100,6 @@ void SendMPDialog::setModel(WalletModel *model)
 
 void SendMPDialog::updatePropSelector()
 {
-    //printf("sendmpdialog::updatePropSelector()\n");
     QString spId = ui->propertyComboBox->itemData(ui->propertyComboBox->currentIndex()).toString();
     ui->propertyComboBox->clear();
     for (unsigned int propertyId = 1; propertyId<100000; propertyId++)
@@ -143,10 +140,6 @@ void SendMPDialog::clearFields()
 
 void SendMPDialog::updateFrom()
 {
-    // update wallet balances
-    set_wallet_totals();
-    updateBalances();
-
     // check if this from address has sufficient fees for a send, if not light up warning label
     QString selectedFromAddress = ui->sendFromComboBox->currentText();
     int64_t inputTotal = feeCheck(selectedFromAddress.toStdString());
@@ -164,9 +157,6 @@ void SendMPDialog::updateFrom()
 
 void SendMPDialog::updateProperty()
 {
-    // update wallet balances
-    set_wallet_totals();
-
     // get currently selected from address
     QString currentSetFromAddress = ui->sendFromComboBox->currentText();
 
@@ -206,7 +196,6 @@ void SendMPDialog::updateProperty()
     {
         ui->amountLineEdit->setPlaceholderText("Enter Indivisible Amount");
     }
-    updateBalances();
 }
 
 void SendMPDialog::updateBalances()
@@ -433,12 +422,15 @@ void SendMPDialog::sendMPTransaction()
 
 void SendMPDialog::sendFromComboBoxChanged(int idx)
 {
+    updateBalances();
     updateFrom();
 }
 
 void SendMPDialog::propertyComboBoxChanged(int idx)
 {
     updateProperty();
+    updateBalances();
+    updateFrom();
 }
 
 void SendMPDialog::clearButtonClicked()
@@ -453,6 +445,10 @@ void SendMPDialog::sendButtonClicked()
 
 void SendMPDialog::balancesUpdated()
 {
+    set_wallet_totals();
+
     updatePropSelector();
+    updateProperty();
     updateBalances();
+    updateFrom();
 }

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -42,12 +42,6 @@ WalletModel::WalletModel(CWallet *wallet, OptionsModel *optionsModel, QObject *p
     connect(pollTimer, SIGNAL(timeout()), this, SLOT(pollBalanceChanged()));
     pollTimer->start(MODEL_UPDATE_DELAY);
 
-    // The above timer is too fast for MasterCore usage, we'll have a new one here
-    /*
-    updateTimer = new QTimer(this);
-    connect(updateTimer, SIGNAL(timeout()), this, SLOT(forceUpdateBalances()));
-    updateTimer->start(MASTERCORE_UPDATE_DELAY);
-    */
     subscribeToCoreSignals();
 }
 
@@ -102,38 +96,6 @@ void WalletModel::updateStatus()
         emit encryptionStatusChanged(newEncryptionStatus);
 }
 
-void WalletModel::forceUpdateBalances()
-{
-    // boost::timer t;
-    // Get required locks upfront. This avoids the GUI from getting stuck on
-    // periodical polls if the core is holding the locks for a longer time -
-    // for example, during a wallet rescan.
-    TRY_LOCK(cs_main, lockMain);
-    if(!lockMain)
-        return;
-    TRY_LOCK(wallet->cs_wallet, lockWallet);
-    if(!lockWallet)
-        return;
-
-    qint64 newBalance = getBalance();
-    qint64 newUnconfirmedBalance = getUnconfirmedBalance();
-    qint64 newImmatureBalance = getImmatureBalance();
-
-    if(cachedBalance != newBalance || cachedUnconfirmedBalance != newUnconfirmedBalance || cachedImmatureBalance != newImmatureBalance)
-    {
-        cachedBalance = newBalance;
-        cachedUnconfirmedBalance = newUnconfirmedBalance;
-        cachedImmatureBalance = newImmatureBalance;
-    }
-
-    // force everything to be updated
-    emit balanceChanged(newBalance, newUnconfirmedBalance, newImmatureBalance);
-    if(transactionTableModel) transactionTableModel->updateConfirmations();
-    /* printf("DEBUG: forceUpdate took");
-    std::cout << t.elapsed() << std::endl;
-    printf("\n"); */
-}
-
 void WalletModel::pollBalanceChanged()
 {
     // Get required locks upfront. This avoids the GUI from getting stuck on
@@ -152,7 +114,6 @@ void WalletModel::pollBalanceChanged()
         cachedNumBlocks = chainActive.Height();
 
         checkBalanceChanged();
-        forceUpdateBalances();
         if(transactionTableModel)
             transactionTableModel->updateConfirmations();
     }

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -250,7 +250,6 @@ public slots:
     void updateAddressBook(const QString &address, const QString &label, bool isMine, const QString &purpose, int status);
     /* Current, immature or unconfirmed balance might have changed - emit 'balanceChanged' if so */
     void pollBalanceChanged();
-    void forceUpdateBalances();
 };
 
 #endif // WALLETMODEL_H


### PR DESCRIPTION
- Fix: Missing LOCK of cs_main in selectCoins()
- QT: Remove forceUpdateBalances() in WalletModel()
- QT: Refine updates of "Send" dialog
- QT: In "Overview" unhide "Smart Properties" on update
- QT: in "Overview" align BTC and MSC amounts
