### PR TITLE
QT: respond to state change signal in all tabs

### DIFF
--- a/src/qt/balancesview.cpp
+++ b/src/qt/balancesview.cpp
@@ -6,6 +6,7 @@
 
 #include "addresstablemodel.h"
 #include "bitcoinunits.h"
+#include "clientmodel.h"
 #include "csvmodelwriter.h"
 #include "editaddressdialog.h"
 #include "guiutil.h"
@@ -79,7 +80,7 @@ using namespace leveldb;
 #include <QVBoxLayout>
 
 BalancesView::BalancesView(QWidget *parent) :
-    QWidget(parent), model(0), balancesView(0)
+    QWidget(parent), clientModel(0), walletModel(0), balancesView(0)
 {
     // Build filter row
     setContentsMargins(0,0,0,0);
@@ -187,9 +188,24 @@ BalancesView::BalancesView(QWidget *parent) :
     UpdatePropSelector();
 }
 
+void BalancesView::setClientModel(ClientModel *model)
+{
+    if (model != NULL) {
+        this->clientModel = model;
+        connect(model, SIGNAL(refreshOmniState()), this, SLOT(balancesUpdated()));
+    }
+}
+
+void BalancesView::setWalletModel(WalletModel *model)
+{
+    if (model != NULL) {
+        this->walletModel = model;
+        connect(model, SIGNAL(balanceChanged(qint64, qint64, qint64)), this, SLOT(balancesUpdated()));
+    }
+}
+
 void BalancesView::UpdatePropSelector()
 {
-    //printf("balancesview::propselectorupdatecalled\n");
     QString spId = propSelectorWidget->itemData(propSelectorWidget->currentIndex()).toString();
     propSelectorWidget->clear();
     propSelectorWidget->addItem("Wallet Totals (Summary)","2147483646"); //use last possible ID for summary for now
@@ -224,22 +240,14 @@ void BalancesView::UpdatePropSelector()
     if (propIdx != -1) { propSelectorWidget->setCurrentIndex(propIdx); }
 }
 
-void BalancesView::setModel(WalletModel *model)
-{
-    this->model = model;
-    connect(model, SIGNAL(balanceChanged(qint64, qint64, qint64)), this, SLOT(balancesUpdated()));
-}
-
 void BalancesView::UpdateBalances()
 {
-    //printf("balancesview::updatebalances()\n");
     propSelectorChanged(0);
     UpdatePropSelector();
 }
 
 void BalancesView::propSelectorChanged(int idx)
 {
-    //printf("balancesview::propselectorchanged()\n");
     QString spId = propSelectorWidget->itemData(propSelectorWidget->currentIndex()).toString();
     unsigned int propertyId = spId.toUInt();
     //repopulate with new selected balances

--- a/src/qt/balancesview.h
+++ b/src/qt/balancesview.h
@@ -9,6 +9,7 @@
 
 #include <QWidget>
 
+class ClientModel;
 class TransactionFilterProxy;
 class WalletModel;
 
@@ -32,8 +33,9 @@ class BalancesView : public QWidget
 
 public:
     explicit BalancesView(QWidget *parent = 0);
+    void setClientModel(ClientModel *model);
+    void setWalletModel(WalletModel *model);
 
-    void setModel(WalletModel *model);
     void UpdateBalances();
     void UpdatePropSelector();
     // Date ranges for filter
@@ -57,7 +59,8 @@ public:
     };
 
 private:
-    WalletModel *model;
+    ClientModel *clientModel;
+    WalletModel *walletModel;
     TransactionFilterProxy *transactionProxyModel;
     QTableView *balancesView;
     QTableView *view;

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -365,9 +365,6 @@ void OverviewPage::setBalance(qint64 balance, qint64 unconfirmedBalance, qint64 
     // alert status with the update balance signal that comes in after each block to see if it had any alerts in it
     updateAlerts();
 
-    // Update Omni balances also when we catch this
-    updateOmni();
-
     int unit = walletModel->getOptionsModel()->getDisplayUnit();
     currentBalance = balance;
     currentUnconfirmedBalance = unconfirmedBalance;
@@ -424,6 +421,9 @@ void OverviewPage::setWalletModel(WalletModel *model)
         // Keep up to date with wallet
         setBalance(model->getBalance(), model->getUnconfirmedBalance(), model->getImmatureBalance());
         connect(model, SIGNAL(balanceChanged(qint64, qint64, qint64)), this, SLOT(setBalance(qint64, qint64, qint64)));
+
+        // Refresh Omni information in case this was an internal Omni transaction
+        connect(model, SIGNAL(balanceChanged(qint64, qint64, qint64)), this, SLOT(updateOmni()));
 
         connect(model->getOptionsModel(), SIGNAL(displayUnitChanged(int)), this, SLOT(updateDisplayUnit()));
     }

--- a/src/qt/sendmpdialog.h
+++ b/src/qt/sendmpdialog.h
@@ -10,6 +10,7 @@
 #include <QDialog>
 #include <QString>
 
+class ClientModel;
 class OptionsModel;
 class SendMPEntry;
 class SendCoinsRecipient;
@@ -29,8 +30,9 @@ class SendMPDialog : public QDialog
 
 public:
     explicit SendMPDialog(QWidget *parent = 0);
+    void setClientModel(ClientModel *model);
+    void setWalletModel(WalletModel *model);
 
-    void setModel(WalletModel *model);
     void clearFields();
     void sendMPTransaction();
     void updateFrom();
@@ -54,7 +56,8 @@ public slots:
 
 private:
     Ui::SendMPDialog *ui;
-    WalletModel *model;
+    ClientModel *clientModel;
+    WalletModel *walletModel;
     bool fNewRecipientAllowed;
 
     // Process WalletModel::SendCoinsReturn and generate a pair consisting

--- a/src/qt/txhistorydialog.cpp
+++ b/src/qt/txhistorydialog.cpp
@@ -5,12 +5,14 @@
 #include "txhistorydialog.h"
 #include "ui_txhistorydialog.h"
 
+#include "clientmodel.h"
 #include "guiutil.h"
 #include "optionsmodel.h"
 #include "walletmodel.h"
 #include "wallet.h"
 #include "base58.h"
 #include "ui_interface.h"
+#include "walletmodel.h"
 
 #include <boost/filesystem.hpp>
 
@@ -68,10 +70,11 @@ using namespace leveldb;
 TXHistoryDialog::TXHistoryDialog(QWidget *parent) :
     QDialog(parent),
     ui(new Ui::txHistoryDialog),
-    model(0)
+    clientModel(0),
+    walletModel(0)
 {
     ui->setupUi(this);
-    this->model = model;
+    this->walletModel = walletModel;
 
     // setup
     ui->txHistoryTable->setColumnCount(6);
@@ -139,6 +142,22 @@ TXHistoryDialog::TXHistoryDialog(QWidget *parent) :
     ui->txHistoryTable->resizeColumnToContents(5);
     ui->txHistoryTable->setColumnHidden(0, true);
     borrowedColumnResizingFixer->stretchColumnWidth(4);
+}
+
+void TXHistoryDialog::setClientModel(ClientModel *model)
+{
+    if (model != NULL) {
+        this->clientModel = model;
+        connect(model, SIGNAL(refreshOmniState()), this, SLOT(UpdateHistory()));
+    }
+}
+
+void TXHistoryDialog::setWalletModel(WalletModel *model)
+{
+    if (model != NULL) {
+        this->walletModel = model;
+        connect(model, SIGNAL(balanceChanged(qint64, qint64, qint64)), this, SLOT(UpdateHistory()));
+    }
 }
 
 void TXHistoryDialog::CreateRow(int rowcount, bool valid, bool bInbound, int confirmations, std::string txTimeStr, std::string displayType, std::string displayAddress, std::string displayAmount, std::string txidStr, bool fundsMoved)
@@ -484,12 +503,6 @@ void TXHistoryDialog::UpdateHistory()
     // don't burn time doing more work than we need to
     if (rowcount > nCount) break;
     }
-}
-
-void TXHistoryDialog::setModel(WalletModel *model)
-{
-    this->model = model;
-    connect(model, SIGNAL(balanceChanged(qint64, qint64, qint64)), this, SLOT(UpdateHistory()));
 }
 
 void TXHistoryDialog::contextualMenu(const QPoint &point)

--- a/src/qt/txhistorydialog.h
+++ b/src/qt/txhistorydialog.h
@@ -5,7 +5,6 @@
 #ifndef TXHISTORYDIALOG_H
 #define TXHISTORYDIALOG_H
 
-#include "walletmodel.h"
 #include "guiutil.h"
 
 #include <QDialog>
@@ -15,7 +14,9 @@
 #include <QDialogButtonBox>
 #include <QPushButton>
 
+class ClientModel;
 class OptionsModel;
+class WalletModel;
 
 QT_BEGIN_NAMESPACE
 class QUrl;
@@ -33,7 +34,9 @@ class TXHistoryDialog : public QDialog
 public:
     //void FullRefresh();
     explicit TXHistoryDialog(QWidget *parent = 0);
-    void setModel(WalletModel *model);
+    void setClientModel(ClientModel *model);
+    void setWalletModel(WalletModel *model);
+
     void CreateRow(int rowcount, bool valid, bool bInbound, int confirmations, std::string txTimeStr, std::string displayType, std::string displayAddress, std::string displayAmount, std::string txidStr, bool fundsMoved);
     void accept();
     /** Set up the tab chain manually, as Qt messes up the tab chain by default in some cases (issue https://bugreports.qt-project.org/browse/QTBUG-10907).
@@ -60,7 +63,8 @@ public slots:
 
 private:
     Ui::txHistoryDialog *ui;
-    WalletModel *model;
+    ClientModel *clientModel;
+    WalletModel *walletModel;
     QMenu *contextMenu;
 
 private slots:
@@ -77,4 +81,4 @@ signals:
     void message(const QString &title, const QString &message, unsigned int style);
 };
 
-#endif // ORDERHISTORYDIALOG_H
+#endif // TXHISTORYDIALOG_H

--- a/src/qt/walletview.cpp
+++ b/src/qt/walletview.cpp
@@ -198,6 +198,9 @@ void WalletView::setClientModel(ClientModel *clientModel)
     this->clientModel = clientModel;
 
     overviewPage->setClientModel(clientModel);
+    balancesView->setClientModel(clientModel);
+    sendMPTab->setClientModel(clientModel);
+    mpTXTab->setClientModel(clientModel);
 }
 
 void WalletView::setWalletModel(WalletModel *walletModel)
@@ -209,10 +212,10 @@ void WalletView::setWalletModel(WalletModel *walletModel)
     overviewPage->setWalletModel(walletModel);
     receiveCoinsPage->setModel(walletModel);
     sendCoinsTab->setModel(walletModel);
-    sendMPTab->setModel(walletModel);
-    balancesView->setModel(walletModel);
+    sendMPTab->setWalletModel(walletModel);
+    balancesView->setWalletModel(walletModel);
 //    metaDExTab->setModel(walletModel);
-    mpTXTab->setModel(walletModel);
+    mpTXTab->setWalletModel(walletModel);
 //    cancelTab->setModel(walletModel);
 //    orderHistoryTab->setModel(walletModel);
 


### PR DESCRIPTION
It subscribes to the signals:
- refreshOmniState (Omni state trigger after block)
- balanceChanged (BTC trigger)
