### PR TITLE
QT: ask mainnet users once to acknowledge warnings

### DIFF
--- a/src/qt/Makefile.am
+++ b/src/qt/Makefile.am
@@ -196,6 +196,7 @@ BITCOIN_QT_H = \
   macnotificationhandler.h \
   monitoreddatamapper.h \
   notificator.h \
+  omnicore_init.h \
   openuridialog.h \
   optionsdialog.h \
   optionsmodel.h \
@@ -304,6 +305,7 @@ BITCOIN_QT_CPP = \
   intro.cpp \
   monitoreddatamapper.cpp \
   notificator.cpp \
+  omnicore_init.cpp \
   optionsdialog.cpp \
   optionsmodel.cpp \
   qvalidatedlineedit.cpp \

--- a/src/qt/Makefile.am
+++ b/src/qt/Makefile.am
@@ -100,13 +100,8 @@ QT_FORMS_UI = \
   forms/rpcconsole.ui \
   forms/sendcoinsdialog.ui \
   forms/sendcoinsentry.ui \
-  forms/sendmpdialog.ui \
-  forms/txhistorydialog.ui \
-  forms/lookupspdialog.ui \
-  forms/lookupaddressdialog.ui \
-  forms/lookuptxdialog.ui \
   forms/signverifymessagedialog.ui \
-  forms/transactiondescdialog.ui 
+  forms/transactiondescdialog.ui
 
 QT_MOC_CPP = \
   moc_addressbookpage.cpp \
@@ -140,11 +135,6 @@ QT_MOC_CPP = \
   moc_rpcconsole.cpp \
   moc_sendcoinsdialog.cpp \
   moc_sendcoinsentry.cpp \
-  moc_sendmpdialog.cpp \
-  moc_txhistorydialog.cpp \
-  moc_lookupspdialog.cpp \
-  moc_lookupaddressdialog.cpp \
-  moc_lookuptxdialog.cpp \
   moc_signverifymessagedialog.cpp \
   moc_splashscreen.cpp \
   moc_trafficgraphwidget.cpp \
@@ -153,7 +143,6 @@ QT_MOC_CPP = \
   moc_transactionfilterproxy.cpp \
   moc_transactiontablemodel.cpp \
   moc_transactionview.cpp \
-  moc_balancesview.cpp \
   moc_utilitydialog.cpp \
   moc_walletframe.cpp \
   moc_walletmodel.cpp \
@@ -196,7 +185,6 @@ BITCOIN_QT_H = \
   macnotificationhandler.h \
   monitoreddatamapper.h \
   notificator.h \
-  omnicore_init.h \
   openuridialog.h \
   optionsdialog.h \
   optionsmodel.h \
@@ -211,11 +199,6 @@ BITCOIN_QT_H = \
   rpcconsole.h \
   sendcoinsdialog.h \
   sendcoinsentry.h \
-  sendmpdialog.h \
-  txhistorydialog.h \
-  lookupspdialog.h \
-  lookupaddressdialog.h \
-  lookuptxdialog.h \
   signverifymessagedialog.h \
   splashscreen.h \
   trafficgraphwidget.h \
@@ -225,7 +208,6 @@ BITCOIN_QT_H = \
   transactionrecord.h \
   transactiontablemodel.h \
   transactionview.h \
-  balancesview.h \
   utilitydialog.h \
   walletframe.h \
   walletmodel.h \
@@ -234,21 +216,6 @@ BITCOIN_QT_H = \
   winshutdownmonitor.h
 
 RES_ICONS = \
-  res/icons/transaction_invalid.png \
-  res/icons/mp_exchange.png \
-  res/icons/mp_toolbox.png \
-  res/icons/mp_sp.png \
-  res/icons/mp_balances.png \
-  res/icons/mp_history.png \
-  res/icons/mp_home.png \
-  res/icons/mp_receive.png \
-  res/icons/mp_send.png \
-  res/icons/mp_meta_cancelled.png \
-  res/icons/mp_meta_filled.png \
-  res/icons/mp_meta_open.png \
-  res/icons/mp_meta_partialclosed.png \
-  res/icons/mp_meta_partial.png \
-  res/icons/mp_meta_pending.png \
   res/icons/add.png \
   res/icons/address-book.png \
   res/icons/bitcoin.ico \
@@ -305,7 +272,6 @@ BITCOIN_QT_CPP = \
   intro.cpp \
   monitoreddatamapper.cpp \
   notificator.cpp \
-  omnicore_init.cpp \
   optionsdialog.cpp \
   optionsmodel.cpp \
   qvalidatedlineedit.cpp \
@@ -333,11 +299,6 @@ BITCOIN_QT_CPP += \
   recentrequeststablemodel.cpp \
   sendcoinsdialog.cpp \
   sendcoinsentry.cpp \
-  sendmpdialog.cpp \
-  txhistorydialog.cpp \
-  lookupspdialog.cpp \
-  lookupaddressdialog.cpp \
-  lookuptxdialog.cpp \
   signverifymessagedialog.cpp \
   transactiondesc.cpp \
   transactiondescdialog.cpp \
@@ -345,7 +306,6 @@ BITCOIN_QT_CPP += \
   transactionrecord.cpp \
   transactiontablemodel.cpp \
   transactionview.cpp \
-  balancesview.cpp \
   walletframe.cpp \
   walletmodel.cpp \
   walletmodeltransaction.cpp \
@@ -358,6 +318,72 @@ RES_IMAGES = \
   res/images/splash_testnet.png
 
 RES_MOVIES = $(wildcard res/movies/spinner-*.png)
+
+# omni core qt #
+OMNICORE_QT_FORMS_UI = \
+  forms/lookupaddressdialog.ui \
+  forms/lookupspdialog.ui \
+  forms/lookuptxdialog.ui \
+  forms/sendmpdialog.ui \
+  forms/txhistorydialog.ui
+
+OMNICORE_QT_MOC_CPP = \
+  moc_balancesview.cpp \
+  moc_lookupaddressdialog.cpp \
+  moc_lookupspdialog.cpp \
+  moc_lookuptxdialog.cpp \
+  moc_sendmpdialog.cpp \
+  moc_txhistorydialog.cpp
+
+OMNICORE_QT_H = \
+  balancesview.h \
+  lookupaddressdialog.h \
+  lookupspdialog.h \
+  lookuptxdialog.h \
+  omnicore_init.h \
+  sendmpdialog.h \
+  txhistorydialog.h
+
+OMNICORE_QT_CPP = \
+  balancesview.cpp \
+  lookupaddressdialog.cpp \
+  lookupspdialog.cpp \
+  lookuptxdialog.cpp \
+  omnicore_init.cpp \
+  sendmpdialog.cpp \
+  txhistorydialog.cpp
+
+OMNICORE_RES_ICONS = \
+  res/icons/mp_balances.png \
+  res/icons/mp_exchange.png \
+  res/icons/mp_history.png \
+  res/icons/mp_home.png \
+  res/icons/mp_meta_cancelled.png \
+  res/icons/mp_meta_filled.png \
+  res/icons/mp_meta_open.png \
+  res/icons/mp_meta_partial.png \
+  res/icons/mp_meta_partialclosed.png \
+  res/icons/mp_meta_pending.png \
+  res/icons/mp_receive.png \
+  res/icons/mp_send.png \
+  res/icons/mp_sp.png \
+  res/icons/mp_toolbox.png \
+  res/icons/transaction_invalid.png
+
+QT_FORMS_UI += \
+  $(OMNICORE_QT_FORMS_UI)
+
+QT_MOC_CPP += \
+  $(OMNICORE_QT_MOC_CPP)
+
+BITCOIN_QT_H += \
+  $(OMNICORE_QT_H)
+
+BITCOIN_QT_CPP += \
+  $(OMNICORE_QT_CPP)
+
+RES_ICONS += \
+  $(OMNICORE_RES_ICONS)
 
 BITCOIN_RC = res/bitcoin-qt-res.rc
 

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -30,6 +30,8 @@
 #include "wallet.h"
 #endif
 
+#include "omnicore_init.h"
+
 #include <stdint.h>
 
 #include <boost/filesystem/operations.hpp>
@@ -475,7 +477,9 @@ int main(int argc, char *argv[])
 #endif
 
     Q_INIT_RESOURCE(bitcoin);
-    GUIUtil::SubstituteFonts(); //0.9.3merge
+
+    GUIUtil::SubstituteFonts();
+
     BitcoinApplication app(argc, argv);
 #if QT_VERSION > 0x050100
     // Generate high-dpi pixmaps
@@ -593,47 +597,26 @@ int main(int argc, char *argv[])
     if (GetBoolArg("-splash", true) && !GetBoolArg("-min", false))
         app.createSplashScreen(isaTestNet);
 
-    /// Show warning
-    string strWarningText = "This software is EXPERIMENTAL software for TESTNET TRANSACTIONS only. USE ON MAINNET AT YOUR OWN RISK.\n\n";
-    strWarningText += "The protocol and transaction processing rules for Mastercoin are still under active development and are subject to change in future.\n\n";
-    strWarningText += "Omni Core should be considered an alpha-level product, and you use it at your own risk. Neither the Omni Foundation nor the Omni Core developers assumes any responsibility for funds misplaced, mishandled, lost, or misallocated.\n\n";
-    strWarningText += "Further, please note that this installation of Omni Core should be viewed as EXPERIMENTAL. Your wallet data may be lost, deleted, or corrupted, with or without warning due to bugs or glitches. Please take caution.\n\n";
-    strWarningText += "This software is provided open-source at no cost. You are responsible for knowing the law in your country and determining if your use of this software contravenes any local laws.\n\n";
-    strWarningText += "DO NOT use wallet(s) with any significant amount of any property/currency while testing!";
-    QString warningText = QString::fromStdString(strWarningText);
-    QMessageBox warningDialog;
-    warningDialog.setIcon(QMessageBox::Warning);
-    warningDialog.setWindowTitle("WARNING - Experimental Software");
-    warningDialog.setText(warningText);
-    warningDialog.setStandardButtons(QMessageBox::No|QMessageBox::Yes);
-    warningDialog.setDefaultButton(QMessageBox::Yes);
-    warningDialog.setButtonText( QMessageBox::No, "Exit" );
-    warningDialog.setButtonText( QMessageBox::Yes, "Acknowledge + Continue" );
-    if(warningDialog.exec() == QMessageBox::No)
+    // Initialize Omni Core and quit on failure
+    if (!OmniCore::Initialize())
+        return 1;
+
+    try
     {
-        // exit, user does not agree to warning
-        qApp->quit();
-    }
-    else
-    {
-        try
-        {
-            app.createWindow(isaTestNet);
-            app.requestInitialize();
-        #if defined(Q_OS_WIN) && QT_VERSION >= 0x050000
-            WinShutdownMonitor::registerShutdownBlockReason(QObject::tr("Bitcoin Core didn't yet exit safely..."), (HWND)app.getMainWinId());
-        #endif
-            app.exec();
-            app.requestShutdown();
-            app.exec();
-        }
-        catch (std::exception& e) {
-            PrintExceptionContinue(&e, "Runaway exception");
-            app.handleRunawayException(QString::fromStdString(strMiscWarning));
-        } catch (...) {
-            PrintExceptionContinue(NULL, "Runaway exception");
-            app.handleRunawayException(QString::fromStdString(strMiscWarning));
-        }
+        app.createWindow(isaTestNet);
+        app.requestInitialize();
+#if defined(Q_OS_WIN) && QT_VERSION >= 0x050000
+        WinShutdownMonitor::registerShutdownBlockReason(QObject::tr("Bitcoin Core didn't yet exit safely..."), (HWND)app.getMainWinId());
+#endif
+        app.exec();
+        app.requestShutdown();
+        app.exec();
+    } catch (std::exception& e) {
+        PrintExceptionContinue(&e, "Runaway exception");
+        app.handleRunawayException(QString::fromStdString(strMiscWarning));
+    } catch (...) {
+        PrintExceptionContinue(NULL, "Runaway exception");
+        app.handleRunawayException(QString::fromStdString(strMiscWarning));
     }
     return app.getReturnValue();
 }

--- a/src/qt/bitcoin.qrc
+++ b/src/qt/bitcoin.qrc
@@ -1,16 +1,18 @@
-<!DOCTYPE RCC><RCC version="1.0"> 
+<!DOCTYPE RCC><RCC version="1.0">
     <qresource prefix="/icons">
-        <file alias="transaction_invalid">res/icons/transaction_invalid.png</file>
+        <!-- Omni Core QT -->
+        <file alias="balances">res/icons/mp_balances.png</file>
+        <file alias="exchange">res/icons/mp_exchange.png</file>
         <file alias="meta_cancelled">res/icons/mp_meta_cancelled.png</file>
         <file alias="meta_filled">res/icons/mp_meta_filled.png</file>
         <file alias="meta_open">res/icons/mp_meta_open.png</file>
+        <file alias="meta_partial">res/icons/mp_meta_partial.png</file>
         <file alias="meta_partialclosed">res/icons/mp_meta_partialclosed.png</file>
-        <file alias="meta_partial">res/icons/mp_meta_partial.png</file>      
         <file alias="meta_pending">res/icons/mp_meta_pending.png</file>
-        <file alias="balances">res/icons/mp_balances.png</file> 
-        <file alias="toolbox">res/icons/mp_toolbox.png</file>
-        <file alias="exchange">res/icons/mp_exchange.png</file>
         <file alias="smartproperty">res/icons/mp_sp.png</file>
+        <file alias="toolbox">res/icons/mp_toolbox.png</file>
+        <file alias="transaction_invalid">res/icons/transaction_invalid.png</file>
+        <!-- /Omni Core QT -->
         <file alias="bitcoin">res/icons/bitcoin.png</file>
         <file alias="address-book">res/icons/address-book.png</file>
         <file alias="quit">res/icons/quit.png</file>

--- a/src/qt/omnicore_init.cpp
+++ b/src/qt/omnicore_init.cpp
@@ -1,0 +1,116 @@
+#include "omnicore_init.h"
+
+#include "chainparams.h"
+#include "util.h"
+
+#include <string>
+
+#include <QMessageBox>
+#include <QSettings>
+
+namespace OmniCore {
+
+/**
+ * Creates a message box with general warnings and potential risks
+ *
+ * @return True if the user acknowledged the warnings
+ */
+static bool getDisclaimerDialogResult()
+{
+    QString qstrTitle("WARNING - Experimental Software");
+
+    QString qstrText(
+    "This software is EXPERIMENTAL software. USE ON MAINNET AT YOUR OWN RISK.");
+
+    QString qstrInformativeText(
+    "The protocol and transaction processing rules for Mastercoin are still under "
+    "active development and are subject to change in future.\n\n"
+    "Omni Core should be considered an alpha-level product, and you use it at your "
+    "own risk. Neither the Omni Foundation nor the Omni Core developers assumes "
+    "any responsibility for funds misplaced, mishandled, lost, or misallocated.\n\n"
+    "Further, please note that this installation of Omni Core should be viewed as "
+    "EXPERIMENTAL. Your wallet data may be lost, deleted, or corrupted, with or "
+    "without warning due to bugs or glitches. Please take caution.\n\n"
+    "This software is provided open-source at no cost. You are responsible for "
+    "knowing the law in your country and determining if your use of this software "
+    "contravenes any local laws.\n\n"
+    "DO NOT use wallet(s) with any significant amount of any property or currency "
+    "while testing!");
+
+    QMessageBox msgBoxDisclaimer;
+    msgBoxDisclaimer.setIcon(QMessageBox::Warning);
+    msgBoxDisclaimer.setWindowTitle(qstrTitle);
+    msgBoxDisclaimer.setText(qstrText);
+    msgBoxDisclaimer.setInformativeText(qstrInformativeText);
+    msgBoxDisclaimer.setStandardButtons(QMessageBox::Abort|QMessageBox::Ok);
+    msgBoxDisclaimer.setDefaultButton(QMessageBox::Ok);
+    msgBoxDisclaimer.setButtonText(QMessageBox::Abort, "&Exit");
+    msgBoxDisclaimer.setButtonText(QMessageBox::Ok, "Acknowledge + &Continue");
+
+    return msgBoxDisclaimer.exec() == QMessageBox::Ok;
+}
+
+/**
+ * Determines if a disclaimer about the use of this software should be shown
+ *
+ * @see AskUserToAcknowledgeRisks()
+ * @return True if the dialog should be shown
+ */
+static bool showDisclaimer()
+{
+    // Don't skip, if disclaimer was requested explicitly
+    if (GetBoolArg("-disclaimer", false))
+        return true;
+
+    // Skip when starting minimized
+    if (GetBoolArg("-min", false))
+        return false;
+
+    // Only mainnet users face the risk of monetary loss
+    if (Params().NetworkID() != CChainParams::MAIN)
+        return false;
+
+    QSettings settings;
+
+    // Check whether the disclaimer was acknowledged before
+    return settings.value("OmniCore/fShowDisclaimer", true).toBool();
+}
+
+/**
+ * Shows an user dialog with general warnings and potential risks
+ *
+ * The user is asked to acknowledge the risks related to the use of
+ * this software. The decision of the user is stored and can be used
+ * to skip the dialog during initialization.
+ *
+ * @see getDisclaimerDialogResult()
+ * @see Initialize()
+ * @return True if the user acknowledged the warnings
+ */
+bool AskUserToAcknowledgeRisks()
+{
+    QSettings settings;
+
+    // Show message box
+    bool fAccepted = getDisclaimerDialogResult();
+
+    // Store decision and show next time, if declined
+    settings.setValue("OmniCore/fShowDisclaimer", !fAccepted);
+
+    return fAccepted;
+}
+
+/**
+ * Setup and initialization related to Omni Core Qt
+ *
+ * @return True if the initialization was successful
+ */
+bool Initialize()
+{
+    if (showDisclaimer())
+        return AskUserToAcknowledgeRisks();
+
+    return true;
+}
+
+} // namespace OmniCore

--- a/src/qt/omnicore_init.h
+++ b/src/qt/omnicore_init.h
@@ -1,0 +1,13 @@
+#ifndef OMNICORE_QT_INIT_H
+#define OMNICORE_QT_INIT_H
+
+namespace OmniCore
+{
+    //! Shows an user dialog with general warnings and potential risks
+    bool AskUserToAcknowledgeRisks();
+
+    //! Setup and initialization related to Omni Core Qt
+    bool Initialize();
+}
+
+#endif // OMNICORE_QT_INIT_H


### PR DESCRIPTION
The disclaimer is shown:
- On mainnet and if it is the first time
- Or it was explicitly requested with the option `-disclaimer`

The disclaimer is not shown:
- On testnet and in regtest mode
- Or it was acknowledged on mainnet
- Or the option `-min` is used

The other goal of this PR is to begin with isolating Omni Core related files and code, and to restore the original format of the underlying codebase to some degree, to make a transition easier.
