### PR TITLE
Application: isolate and replace version and build information

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -141,6 +141,7 @@ libbitcoin_common_a_SOURCES = \
   mastercore_rpc.cpp \
   mastercore_dex.cpp \
   mastercore_sp.cpp \
+  mastercore_version.cpp \
   hash.cpp \
   key.cpp \
   netbase.cpp \

--- a/src/mastercore.cpp
+++ b/src/mastercore.cpp
@@ -642,7 +642,7 @@ bool mastercore::checkExpiredAlerts(unsigned int curBlock, uint64_t curTime)
                      }
                  break;
                  case 3: //Text based alert only expiring by client version, show alert in UI and getalert_MP call, ignores type check value (eg use 0)
-                     if (OMNICORE_VERSION_BASE > expiryValue)
+                     if (OMNICORE_VERSION > expiryValue)
                      {
                          //the alert has expired, clear the global alert string
                          file_log("DEBUG ALERT - Expiring alert string %s\n",global_alert_message.c_str());

--- a/src/mastercore_rpc.cpp
+++ b/src/mastercore_rpc.cpp
@@ -4,7 +4,6 @@
 #include "util.h"
 #include "init.h"
 #include "wallet.h"
-#include "clientversion.h"
 
 #include <stdint.h>
 #include <string.h>
@@ -1921,9 +1920,9 @@ Value getinfo_MP(const Array& params, bool fHelp)
     // other bits of info we want to report should be included here
 
     // provide the mastercore and bitcoin version and if available commit id
-    infoResponse.push_back(Pair("mastercoreversion", "0.0." + strprintf("%.1f",(double)OMNICORE_VERSION_BASE/10) + OMNICORE_VERSION_TYPE ));
-    infoResponse.push_back(Pair("bitcoincoreversion", "0." + boost::lexical_cast<string>((int)CLIENT_VERSION/100)));
-    infoResponse.push_back(Pair("commitinfo", COMMIT_INFO));
+    infoResponse.push_back(Pair("mastercoreversion", OmniCoreVersion()));
+    infoResponse.push_back(Pair("bitcoincoreversion", BitcoinCoreVersion()));
+    infoResponse.push_back(Pair("commitinfo", BuildCommit()));
 
     // provide the current block details
     uint64_t block = chainActive.Height();

--- a/src/mastercore_version.cpp
+++ b/src/mastercore_version.cpp
@@ -1,0 +1,75 @@
+#include "mastercore_version.h"
+
+#include "clientversion.h"
+#include "util.h"
+
+#include <string>
+
+#ifdef HAVE_BUILD_INFO
+#    include "build.h"
+#endif
+
+#ifndef COMMIT_ID
+#   ifdef GIT_ARCHIVE
+#       define COMMIT_ID "$Format:%h$"
+#   elif defined(BUILD_SUFFIX)
+#       define COMMIT_ID STRINGIZE(BUILD_SUFFIX)
+#   else
+#       define COMMIT_ID ""
+#   endif
+#endif
+
+#ifndef BUILD_DATE
+#    ifdef GIT_COMMIT_DATE
+#        define BUILD_DATE GIT_COMMIT_DATE
+#    else
+#        define BUILD_DATE __DATE__ ", " __TIME__
+#    endif
+#endif
+
+//! Returns formatted Omni Core version, e.g. "0.0.9.1-dev"
+const std::string OmniCoreVersion()
+{
+    // TODO: replace zeros at some point
+    if (OMNICORE_VERSION_PATCH) {
+        return strprintf("0.0.%d.%d.%d%s",
+                OMNICORE_VERSION_MAJOR,
+                OMNICORE_VERSION_MINOR,
+                OMNICORE_VERSION_PATCH,
+                OMNICORE_VERSION_TYPE);
+    } else {
+        return strprintf("0.0.%d.%d%s",
+                OMNICORE_VERSION_MAJOR,
+                OMNICORE_VERSION_MINOR,
+                OMNICORE_VERSION_TYPE);
+    }
+}
+
+//! Returns formatted Bitcoin Core version, e.g. "0.10", "0.9.3"
+const std::string BitcoinCoreVersion()
+{
+    if (CLIENT_VERSION_BUILD) {
+        return strprintf("%d.%d.%d.%d",
+                CLIENT_VERSION_MAJOR,
+                CLIENT_VERSION_MINOR,
+                CLIENT_VERSION_REVISION,
+                CLIENT_VERSION_BUILD);
+    } else {
+        return strprintf("%d.%d.%d",
+                CLIENT_VERSION_MAJOR,
+                CLIENT_VERSION_MINOR,
+                CLIENT_VERSION_REVISION);
+    }
+}
+
+//! Returns build date
+const std::string BuildDate()
+{
+    return std::string(BUILD_DATE);
+}
+
+//! Returns commit identifier, if available
+const std::string BuildCommit()
+{
+    return std::string(COMMIT_ID);
+}

--- a/src/mastercore_version.h
+++ b/src/mastercore_version.h
@@ -3,9 +3,6 @@
 
 #include <string>
 
-// To be depreciated!
-#define OMNICORE_VERSION_BASE    91 // 82 = 0.0.8.2   91 = 0.0.9.1   103 = 0.0.10.3 etc
-
 // Increase with every consensus affecting change
 #define OMNICORE_VERSION_MAJOR   9
 

--- a/src/mastercore_version.h
+++ b/src/mastercore_version.h
@@ -1,16 +1,40 @@
-// Copyright (c) 2013 The Bitcoin developers
-// Distributed under the MIT/X11 software license, see the accompanying
-// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+#ifndef OMNICORE_VERSION_H
+#define OMNICORE_VERSION_H
 
-#ifndef _MASTERCORE_VERSION_H
-#define _MASTERCORE_VERSION_H
+#include <string>
 
-  #define OMNICORE_VERSION_BASE 91 // 82 = 0.0.8.2   91 = 0.0.9.1   103 = 0.0.10.3 etc
-  #define OMNICORE_VERSION_TYPE "-dev" // switch to -rel for tags, switch back to -dev for development
+// To be depreciated!
+#define OMNICORE_VERSION_BASE    91 // 82 = 0.0.8.2   91 = 0.0.9.1   103 = 0.0.10.3 etc
 
-  /* next tag on 9 branch must contain ONLY non-consensus affecting fixes
-  #define OMNICORE_VERSION_BASE 91
-  #define OMNICORE_VERSION_TYPE "-rel"
-  */
+// Increase with every consensus affecting change
+#define OMNICORE_VERSION_MAJOR   9
 
-#endif
+// Increase with every non-consensus affecting feature
+#define OMNICORE_VERSION_MINOR   1
+
+// Increase with every patch, which is not a feature or consensus affecting
+#define OMNICORE_VERSION_PATCH   0
+
+// Use "-dev" for development versions, switch to "-rel" for tags
+#define OMNICORE_VERSION_TYPE    "-dev"
+
+
+//! Omni Core client version
+static const int OMNICORE_VERSION =
+                        +  100000 * OMNICORE_VERSION_MAJOR
+                        +     100 * OMNICORE_VERSION_MINOR
+                        +       1 * OMNICORE_VERSION_PATCH;
+
+//! Returns formatted Omni Core version, e.g. "0.0.9.1-dev"
+const std::string OmniCoreVersion();
+
+//! Returns formatted Bitcoin Core version, e.g. "0.10", "0.9.3"
+const std::string BitcoinCoreVersion();
+
+//! Returns build date
+const std::string BuildDate();
+
+//! Returns commit identifier, if available
+const std::string BuildCommit();
+
+#endif // OMNICORE_VERSION_H

--- a/src/qt/splashscreen.cpp
+++ b/src/qt/splashscreen.cpp
@@ -11,10 +11,11 @@
 #ifdef ENABLE_WALLET
 #include "wallet.h"
 #endif
-#include <QMessageBox>
+
+#include "mastercore_version.h"
+
 #include <QApplication>
 #include <QPainter>
-#include "mastercore_version.h"
 
 SplashScreen::SplashScreen(const QPixmap &pixmap, Qt::WindowFlags f, bool isTestNet) :
     QSplashScreen(pixmap, f)
@@ -30,10 +31,11 @@ SplashScreen::SplashScreen(const QPixmap &pixmap, Qt::WindowFlags f, bool isTest
     float fontFactor            = 1.0;
 
     // define text to place
-    string coreVersionStr = "Experimental UI 0.0." + strprintf("%.1f",(double)OMNICORE_VERSION_BASE/10) + OMNICORE_VERSION_TYPE;
     QString titleText       = tr("Omni Core");
-    QString versionText     = QString::fromStdString(coreVersionStr);
-    QString copyrightText   = QChar(0xA9)+QString(" 2009-%1 ").arg(COPYRIGHT_YEAR) + QString(tr("The Bitcoin Core developers, ")) + QChar(0xA9)+QString(" 2013-%1 ").arg(COPYRIGHT_YEAR) + QString(tr("The Omni Layer developers"));
+    QString versionText     = QString("Experimental UI %1").arg(QString::fromStdString(OmniCoreVersion()));
+    QString copyrightText   = QChar(0xA9)+QString(" 2009-%1 ").arg(COPYRIGHT_YEAR) + QString(tr("The Bitcoin Core developers"));
+    copyrightText          += QString(", ");
+    copyrightText          += QChar(0xA9)+QString(" 2013-%1 ").arg(COPYRIGHT_YEAR) + QString(tr("The Omni Core developers"));
     QString testnetAddText  = QString(tr("[testnet]")); // define text to place as single text object
 
     QString font            = "Arial";

--- a/src/qt/utilitydialog.cpp
+++ b/src/qt/utilitydialog.cpp
@@ -15,10 +15,10 @@
 #include "init.h"
 #include "util.h"
 
+#include "mastercore_version.h"
+
 #include <QLabel>
 #include <QVBoxLayout>
-#include <boost/lexical_cast.hpp>
-#include "mastercore_version.h"
 
 /** "About" dialog box */
 AboutDialog::AboutDialog(QWidget *parent) :
@@ -36,7 +36,7 @@ void AboutDialog::setModel(ClientModel *model)
 {
     if(model)
     {
-        QString version = QString::fromStdString("0.0." + boost::lexical_cast<std::string>((double)OMNICORE_VERSION_BASE/10) + OMNICORE_VERSION_TYPE);
+        QString version = QString::fromStdString(OmniCoreVersion());
         /* On x86 add a bit specifier to the version so that users can distinguish between
          * 32 and 64 bit builds. On other architectures, 32/64 bit may be more ambigious.
          */
@@ -67,10 +67,10 @@ HelpMessageDialog::HelpMessageDialog(QWidget *parent) :
     ui->setupUi(this);
     GUIUtil::restoreWindowGeometry("nHelpMessageDialogWindow", this->size(), this);
 
-    header = tr("Omni Core") + " " + tr("version") + " " +
-        QString::fromStdString(FormatFullVersion()) + "\n\n" +
+    header = tr("Omni Core") + " v" + QString::fromStdString(OmniCoreVersion()) + "\n" +
+        tr("Bitcoin Core") + " " + QString::fromStdString(FormatFullVersion()) + "\n\n" +
         tr("Usage:") + "\n" +
-        "  bitcoin-qt [" + tr("command-line options") + "]                     " + "\n";
+        "  mastercore-qt [" + tr("command-line options") + "]" + "\n";
 
     coreOptions = QString::fromStdString(HelpMessage(HMM_BITCOIN_QT));
 

--- a/src/version.cpp
+++ b/src/version.cpp
@@ -49,9 +49,6 @@ const std::string CLIENT_NAME("Satoshi");
 #define BUILD_DESC_FROM_UNKNOWN(maj,min,rev,build) \
     "v" DO_STRINGIZE(maj) "." DO_STRINGIZE(min) "." DO_STRINGIZE(rev) "." DO_STRINGIZE(build) "-unk"
 
-#define BUILD_SUFFIX_ONLY(suffix) \
-    DO_STRINGIZE(suffix)
-
 #ifndef BUILD_DESC
 #    ifdef BUILD_SUFFIX
 #        define BUILD_DESC BUILD_DESC_WITH_SUFFIX(CLIENT_VERSION_MAJOR, CLIENT_VERSION_MINOR, CLIENT_VERSION_REVISION, CLIENT_VERSION_BUILD, BUILD_SUFFIX)
@@ -70,12 +67,5 @@ const std::string CLIENT_NAME("Satoshi");
 #    endif
 #endif
 
-#ifdef BUILD_SUFFIX
-#    define COMMIT_DEF BUILD_SUFFIX_ONLY(BUILD_SUFFIX)
-#else
-#    define COMMIT_DEF ""
-#endif
-
-const std::string COMMIT_INFO(COMMIT_DEF);
 const std::string CLIENT_BUILD(BUILD_DESC CLIENT_VERSION_SUFFIX);
 const std::string CLIENT_DATE(BUILD_DATE);

--- a/src/version.h
+++ b/src/version.h
@@ -21,7 +21,7 @@ static const int CLIENT_VERSION =
 extern const std::string CLIENT_NAME;
 extern const std::string CLIENT_BUILD;
 extern const std::string CLIENT_DATE;
-extern const std::string COMMIT_INFO;
+
 //
 // network protocol versioning
 //


### PR DESCRIPTION
Starting with the most controversial change, which may need further input or refinement:
1. The version and build information are no longer done inline with support of `version.cpp/.h`, but "in house" within `mastercore_version.cpp/.h`, which is now almost a copy of `version.cpp`. This was done for two reasons: a) reset `version.cpp/.h` to it's original state, but more relevant: b) to cover all cases. While the commit information was available for "standard" builds, the old version did not cover the case where a release is exported, e.g. via Gitian building.
2. It replaces the use of variables with methods such as `OmniCoreVersion()` and `BuildCommit()`. It does not have to be this way, but it appeared more suitable.
3. There is `OmniCoreVersion()`, which returns for example `"0.0.9.1-dev"` and `OmniCoreRelease()`, which currently returns `"Experimental UI 0.0.9.1-dev"`. The later is used in the splash screen and help message text for `mastercore-qt`. The function names might not be intuitive, and something like `OmniCoreVersionLong()` might be more appropriate. Input on this is very welcomed.
4. Probably less controversial are the other changes: further rebranding of `"Bitcoin"`, `"Bitcoin Core"`, `"Omnicore"` to `"Omni Core"`.

Example old:
![version_pr_old](https://cloud.githubusercontent.com/assets/5836089/6367727/59322cb0-bcd6-11e4-9a0e-803a50471763.png)

Example updated:
![version_pr_new](https://cloud.githubusercontent.com/assets/5836089/6367735/6031c53e-bcd6-11e4-9669-0cdcd534dabb.png)
