### PR TITLE
Initialization: detect out of order block storage earlier

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -827,6 +827,23 @@ bool AppInit2(boost::thread_group& threadGroup)
         }
     }
 
+    // ********************************************************* Step 7.1: storage guard
+
+    uiInterface.InitMessage(_("Performing out of order block detection..."));
+
+    bool fUnsupportedBlockStorage = CheckForOutOfOrderBlockStorage();
+    if (fUnsupportedBlockStorage) {
+        return InitError(_(
+                "Out of order stored blocks detected.\n\n"
+                "This indicates the use of a Bitcoin Core 0.10 blockchain "
+                "with headers first synchronization which may result in "
+                "unexpected side effects.\n\n"
+                "As a precaution Bitcoin Core 0.10 is currently not supported."
+            ));
+    }
+
+    // ********************************************************* Step 7.2: continue loading chain
+
     // cache size calculations
     size_t nTotalCache = (GetArg("-dbcache", nDefaultDbCache) << 20);
     if (nTotalCache < (nMinDbCache << 20))
@@ -958,20 +975,7 @@ bool AppInit2(boost::thread_group& threadGroup)
         return false;
     }
 
-    // ********************************************************* Step 7.5: load omni core
-
-    uiInterface.InitMessage(_("Performing out of order block detection..."));
-
-    bool fUnsupportedBlockStorage = CheckForOutOfOrderBlockStorage();
-    if (fUnsupportedBlockStorage) {
-        return InitError(_(
-                "Out of order stored blocks detected.\n\n"
-                "This indicates the use of a Bitcoin Core 0.10 blockchain "
-                "with headers first synchronization which may result in "
-                "unexpected side effects.\n\n"
-                "As a precaution Bitcoin Core 0.10 is currently not supported."
-            ));
-    }
+    // ********************************************************* Step 7.3: load omni core
 
     if (fDisableWallet) {
         return InitError(_(
@@ -981,7 +985,7 @@ bool AppInit2(boost::thread_group& threadGroup)
             ));
     }
 
-    if (!fTxIndex) { // we flip txindex default to true, so should only see this if user actually specifies txindex=0
+    if (!fTxIndex) {
         return InitError(_(
                 "Disabled transaction index detected.\n\n"
                 "Omni Core requires an enabled transaction index. To enable "

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3060,7 +3060,7 @@ bool CheckForOutOfOrderBlockStorage()
         }
 
         if (nPos <= nPosPrev) {
-            // found a blocks stored out of order
+            // found a block stored out of order
             return true;
         }
 


### PR DESCRIPTION
The out of order block storage detection should be done as soon as possible, to avoid the user triggers other actions, which could turn out to be fruitless or harmful, such as reindexing.
