### PR TITLE
Initialization: lock cs_main during out of order block storage detection

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3040,7 +3040,7 @@ bool InitBlockIndex() {
 
 bool CheckForOutOfOrderBlockStorage()
 {
-    AssertLockHeld(cs_main);
+    LOCK(cs_main);
 
     int nHeight = 0;
     int nFilePrev = 0;


### PR DESCRIPTION
A build with enabled DDEBUG_LOCKORDER revealed a lock assertion failure related to that line, thus the lock is explicitly set.
