### PR TITLE
Log: don't print transaction info to console

### DIFF
--- a/src/mastercore.cpp
+++ b/src/mastercore.cpp
@@ -395,8 +395,6 @@ static CMPPending *pendingDelete(const uint256 txid, bool bErase = false)
     // display
     CMPPending *p_pending = &(it->second);
 
-    p_pending->print(txid);
-
     int64_t src_amount = getMPbalance(p_pending->src, p_pending->prop, PENDING);
 
     if (msc_debug_verbose3) file_log("%s()src= %ld, line %d, file: %s\n", __FUNCTION__, src_amount, __LINE__, __FILE__);
@@ -2643,8 +2641,6 @@ int interp_ret = -555555, pop_ret;
 
     interp_ret = mp_obj.interpretPacket();
     if (interp_ret) file_log("!!! interpretPacket() returned %d !!!\n", interp_ret);
-
-    mp_obj.print();
 
     // of course only MP-related TXs get recorded
     if (!disableLevelDB)


### PR DESCRIPTION
Disables printing in the context of:
- removing a transaction from the pending transactions list
- a newly processed transaction within the transaction handler

Printing to the console should be reserved for exceptional situations such as signaling a shutdown caused by an alert.

This is related to #30.
