### PR TITLE
QT: value handling optimizations and cleanup of unused

### DIFF
--- a/src/qt/txhistorydialog.cpp
+++ b/src/qt/txhistorydialog.cpp
@@ -186,8 +186,7 @@ int TXHistoryDialog::PopulateHistoryMap()
         int64_t amount = pending.amount;
         // create a HistoryTXObject and add to map
         HistoryTXObject htxo;
-        htxo.blockHeight = 0; // how are we gonna order pending txs????
-        htxo.blockByteOffset = 0; // attempt to use the position of the transaction in the wallet to provide a sortkey for pending
+        // attempt to use the position of the transaction in the wallet to provide a sortkey for pending
         const CWalletTx* pendingWTx = wallet->GetWalletTx(txid);
         if (NULL != pendingWTx) {
             htxo.blockByteOffset = pendingWTx->nOrderPos;
@@ -267,7 +266,6 @@ int TXHistoryDialog::PopulateHistoryMap()
                         // create a HistoryTXObject and add to map
                         HistoryTXObject htxo;
                         htxo.blockHeight = atoi(svstr[1]);
-                        htxo.blockByteOffset = 0;
                         CDiskTxPos position;
                         if (pblocktree->ReadTxIndex(stoHash, position)) {
                             htxo.blockByteOffset = position.nTxOffset;
@@ -320,7 +318,6 @@ int TXHistoryDialog::PopulateHistoryMap()
                     // create a HistoryTXObject and add to map
                     HistoryTXObject htxo;
                     htxo.blockHeight = blockHeight;
-                    htxo.blockByteOffset = 0; // needs further investigation
                     if (!bIsBuy) { htxo.txType = "DEx Sell"; htxo.address = tmpSeller; } else { htxo.txType = "DEx Buy"; htxo.address = tmpBuyer; }
                     htxo.amount=(!bIsBuy ? "-" : "") + FormatDivisibleShortMP(total)+getTokenLabel(tmpPropertyId);
                     htxo.fundsMoved=true;
@@ -371,7 +368,6 @@ int TXHistoryDialog::PopulateHistoryMap()
                 // create a HistoryTXObject and add to map
                 HistoryTXObject htxo;
                 htxo.blockHeight = blockHeight;
-                htxo.blockByteOffset = 0;
                 CDiskTxPos position;
                 if (pblocktree->ReadTxIndex(hash, position)) {
                     htxo.blockByteOffset = position.nTxOffset;

--- a/src/qt/txhistorydialog.cpp
+++ b/src/qt/txhistorydialog.cpp
@@ -415,9 +415,9 @@ void TXHistoryDialog::UpdateConfirmations()
         }
         if (confirmations > 5) ic = QIcon(":/icons/transaction_confirmed");
         if (!valid) ic = QIcon(":/icons/transaction_invalid");
-        QTableWidgetItem *iconCell = new QTableWidgetItem;
+        QTableWidgetItem *iconCell = ui->txHistoryTable->item(row, 2);
+        if (NULL == iconCell) continue; // fail safe
         iconCell->setIcon(ic);
-        ui->txHistoryTable->setItem(row, 2, iconCell);
     }
 }
 

--- a/src/qt/txhistorydialog.cpp
+++ b/src/qt/txhistorydialog.cpp
@@ -176,8 +176,7 @@ int TXHistoryDialog::PopulateHistoryMap()
         // grab txid
         const uint256& txid = it->first;
         // check historyMap, if this tx exists don't waste resources doing anymore work on it
-        HistoryMap::iterator hIter = txHistoryMap.find(txid);
-        if (hIter != txHistoryMap.end()) continue;
+        if (txHistoryMap.find(txid) != txHistoryMap.end()) continue;
         // grab pending object & extract details
         const CMPPending& pending = it->second;
         std::string senderAddress = pending.src;
@@ -247,7 +246,7 @@ int TXHistoryDialog::PopulateHistoryMap()
             int blockHeight = pBlockIndex->nHeight; // get the height of the transaction
 
             // ### START STO INSERTION CHECK ###
-            for(uint32_t i = 0; i<vecReceipts.size(); i++) {
+            for (size_t i = 0; i < vecReceipts.size(); ++i) {
                 std::vector<std::string> svstr;
                 boost::split(svstr, vecReceipts[i], boost::is_any_of(":"), token_compress_on);
                 if(4 == svstr.size()) // make sure expected num items
@@ -258,8 +257,7 @@ int TXHistoryDialog::PopulateHistoryMap()
                         uint256 stoHash;
                         stoHash.SetHex(svstr[0]);
                         // check historyMap, if this STO exists don't waste resources doing anymore work on it
-                        HistoryMap::iterator hIterator = txHistoryMap.find(stoHash);
-                        if (hIterator != txHistoryMap.end()) continue;
+                        if (txHistoryMap.find(stoHash) != txHistoryMap.end()) continue;
                         // STO not in historyMap, get details
                         uint64_t propertyId = 0;
                         try { propertyId = boost::lexical_cast<uint64_t>(svstr[3]); } // attempt to extract propertyId
@@ -291,7 +289,6 @@ int TXHistoryDialog::PopulateHistoryMap()
             // ### END STO INSERTION CHECK ###
 
             // continuing with wallet tx, we've already confirmed earlier on that it's in txlistdb
-            string statusText;
             unsigned int propertyId = 0;
             uint64_t amount = 0;
             string senderAddress;
@@ -302,8 +299,6 @@ int TXHistoryDialog::PopulateHistoryMap()
             CMPTransaction mp_obj;
             int parseRC = parseTransaction(true, wtx, blockHeight, 0, &mp_obj);
             string displayAmount;
-            string displayToken;
-            string displayValid;
             string displayAddress;
             string displayType;
             if (0 < parseRC) { //positive RC means payment
@@ -415,8 +410,6 @@ void TXHistoryDialog::UpdateConfirmations()
             if (temphtxo.blockHeight > 0) confirmations = (chainHeight + 1) - temphtxo.blockHeight;
             valid = temphtxo.valid;
         }
-        int txBlockHeight = ui->txHistoryTable->item(row,1)->text().toInt();
-        if (txBlockHeight>0) confirmations = (chainHeight+1) - txBlockHeight;
         // setup the appropriate icon
         QIcon ic = QIcon(":/icons/transaction_0");
         switch(confirmations) {
@@ -458,9 +451,9 @@ void TXHistoryDialog::UpdateHistory()
                 const HistoryTXObject& htxo = it->second; // grab the transaction
                 int workingRow = ui->txHistoryTable->rowCount();
                 ui->txHistoryTable->insertRow(workingRow); // append a new row (sorting will take care of ordering)
-                QDateTime txTime;
                 QTableWidgetItem *dateCell = new QTableWidgetItem;
-                if (htxo.blockHeight>0) {
+                if (htxo.blockHeight > 0) {
+                    QDateTime txTime;
                     CBlockIndex* pBlkIdx = chainActive[htxo.blockHeight];
                     if (NULL != pBlkIdx) txTime.setTime_t(pBlkIdx->GetBlockTime());
                     dateCell->setData(Qt::DisplayRole, txTime);

--- a/src/qt/txhistorydialog.h
+++ b/src/qt/txhistorydialog.h
@@ -29,15 +29,17 @@ namespace Ui {
 
 class HistoryTXObject
 {
-
 public:
-  int blockHeight; // block transaction was mined in
-  int blockByteOffset; // byte offset the tx is stored in the block (used for ordering multiple txs same block)
-  bool valid; // whether the transaction is valid from an Omni perspective
-  bool fundsMoved; // whether tokens actually moved in this transaction
-  std::string txType; // human readable string containing type
-  std::string address; // the address to be displayed (usually sender or recipient)
-  std::string amount; // string containing formatted amount
+    HistoryTXObject()
+      : blockHeight(0), blockByteOffset(0), valid(false), fundsMoved(false) {}
+
+    int blockHeight; // block transaction was mined in
+    int blockByteOffset; // byte offset the tx is stored in the block (used for ordering multiple txs same block)
+    bool valid; // whether the transaction is valid from an Omni perspective
+    bool fundsMoved; // whether tokens actually moved in this transaction
+    std::string txType; // human readable string containing type
+    std::string address; // the address to be displayed (usually sender or recipient)
+    std::string amount; // string containing formatted amount
 
 };
 


### PR DESCRIPTION
- use const references where possible in transaction history
- cleanup and remove unused from transaction history
- improve transaction history wallet transaction handling
- transaction history entry initialization with default values
- replace icon, instead of creating a new item in history
