### PR TITLE
Initialization: fix/set default "txindex" value to false

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3012,7 +3012,7 @@ bool InitBlockIndex() {
         return true;
 
     // Use the provided setting for -txindex in the new database
-    fTxIndex = GetBoolArg("-txindex", true);
+    fTxIndex = GetBoolArg("-txindex", false);
     pblocktree->WriteFlag("txindex", fTxIndex);
     LogPrintf("Initializing databases...\n");
 


### PR DESCRIPTION
The default value of "txindex" was changed, but then reverted. During the
reversion this one was missed. This can cause unexpected behavior when starting
with a pristine datadir.
