### PR TITLE
Fix class selection size check

### DIFF
--- a/src/mastercore.cpp
+++ b/src/mastercore.cpp
@@ -2645,7 +2645,7 @@ static bool UseEncodingClassC(size_t nDataSize)
     size_t nTotalSize = nDataSize + 2; // Marker "om"
     bool fDataEnabled = GetBoolArg("-datacarrier", true);
 
-    return nTotalSize < nMaxDatacarrierBytes && fDataEnabled;
+    return nTotalSize <= nMaxDatacarrierBytes && fDataEnabled;
 }
 
 // This function requests the wallet create an Omni transaction using the supplied parameters and payload


### PR DESCRIPTION
Class C selection check should return true in this case:

```
fDataEnabled = true
nMaxDatacarrierBytes = 18

00000000000000010000000000bc614e
nDataSize = 16
nTotalSize = 18

nTotalSize < nMaxDatacarrierBytes && fDataEnabled =
18         < 18                                   = false << unexpected
```
