### PR TITLE
Test, shield and consolidate script handling

### DIFF
--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -83,6 +83,7 @@ endif
 OMNICORE_TESTS = \
   test/mastercore_obfuscation_tests.cpp \
   test/mastercore_rounduint64_tests.cpp \
+  test/mastercore_script_dust_tests.cpp \
   test/mastercore_script_extraction_tests.cpp \
   test/mastercore_strtoint64_tests.cpp \
   test/mastercore_swapbyteorder_tests.cpp

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -85,6 +85,7 @@ OMNICORE_TESTS = \
   test/mastercore_rounduint64_tests.cpp \
   test/mastercore_script_dust_tests.cpp \
   test/mastercore_script_extraction_tests.cpp \
+  test/mastercore_script_solver_tests.cpp \
   test/mastercore_strtoint64_tests.cpp \
   test/mastercore_swapbyteorder_tests.cpp
 

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -83,6 +83,7 @@ endif
 OMNICORE_TESTS = \
   test/mastercore_obfuscation_tests.cpp \
   test/mastercore_rounduint64_tests.cpp \
+  test/mastercore_script_extraction_tests.cpp \
   test/mastercore_strtoint64_tests.cpp \
   test/mastercore_swapbyteorder_tests.cpp
 

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -81,6 +81,7 @@ endif
 
 # Omni Core extensions
 OMNICORE_TESTS = \
+  test/mastercore_obfuscation_tests.cpp \
   test/mastercore_rounduint64_tests.cpp \
   test/mastercore_strtoint64_tests.cpp \
   test/mastercore_swapbyteorder_tests.cpp

--- a/src/mastercore.cpp
+++ b/src/mastercore.cpp
@@ -1081,16 +1081,6 @@ int mastercore::set_wallet_totals()
   return (my_addresses_count);
 }
 
-static bool getOutputType(const CScript& scriptPubKey, txnouttype& whichTypeRet)
-{
-vector<vector<unsigned char> > vSolutions;
-
-  if (!Solver(scriptPubKey, whichTypeRet, vSolutions)) return false;
-
-  return true;
-}
-
-
 int TXExodusFundraiser(const CTransaction &wtx, const string &sender, int64_t ExodusHighestValue, int nBlock, unsigned int nTime)
 {
   if ((nBlock >= GENESIS_BLOCK && nBlock <= LAST_EXODUS_BLOCK) || (isNonMainNet()))
@@ -1173,7 +1163,7 @@ int parseTransaction(bool bRPConly, const CTransaction &wtx, int nBlock, unsigne
   // ### EXODUS MARKER IDENTIFICATION ### - quickly go through the outputs & ensure there is a marker (exodus and/or omni bytes)
   for (unsigned int i = 0; i < wtx.vout.size(); i++) {
       txnouttype outType;
-      if (!getOutputType(wtx.vout[i].scriptPubKey, outType)) continue; //unable to get an output type, ignore
+      if (!GetOutputType(wtx.vout[i].scriptPubKey, outType)) continue; //unable to get an output type, ignore
       if (outType == TX_PUBKEYHASH) { // look for exodus marker
           CTxDestination dest;
           string strAddress;
@@ -1211,7 +1201,7 @@ int parseTransaction(bool bRPConly, const CTransaction &wtx, int nBlock, unsigne
       string strAddress;
       txnouttype whichType;
       bool validType = false;
-      if (!getOutputType(wtx.vout[i].scriptPubKey, whichType)) validType=false;
+      if (!GetOutputType(wtx.vout[i].scriptPubKey, whichType)) validType=false;
       if (isAllowedOutputType(whichType, nBlock)) validType=true;
       if (ExtractDestination(wtx.vout[i].scriptPubKey, dest)) {
           strAddress = CBitcoinAddress(dest).ToString();
@@ -1259,7 +1249,7 @@ int parseTransaction(bool bRPConly, const CTransaction &wtx, int nBlock, unsigne
       txnouttype whichType;
       inAll += txPrev.vout[n].nValue;
       if (ExtractDestination(txPrev.vout[n].scriptPubKey, source)) { // extract the destination of the previous transaction's vout[n] and check it's allowed type
-          if (!getOutputType(txPrev.vout[n].scriptPubKey, whichType)) { ++inputs_errors; break; }
+          if (!GetOutputType(txPrev.vout[n].scriptPubKey, whichType)) { ++inputs_errors; break; }
           if (!isAllowedOutputType(whichType, nBlock)) { ++inputs_errors; break; }
           CBitcoinAddress addressSource(source);
           inputs_sum_of_values[addressSource.ToString()] += txPrev.vout[n].nValue;
@@ -1335,7 +1325,7 @@ int parseTransaction(bool bRPConly, const CTransaction &wtx, int nBlock, unsigne
       int64_t dataAddressValue = 0;
       for (unsigned k = 0; k<script_data.size();k++) { // Step 1, locate the data packet
           txnouttype whichType;
-          if (!getOutputType(wtx.vout[k].scriptPubKey, whichType)) break; // unable to determine type, ignore output
+          if (!GetOutputType(wtx.vout[k].scriptPubKey, whichType)) break; // unable to determine type, ignore output
           if (!isAllowedOutputType(whichType, nBlock)) break;
           string strSub = script_data[k].substr(2,16); // retrieve bytes 1-9 of packet for peek & decode comparison
           seq = (ParseHex(script_data[k].substr(0,2)))[0]; // retrieve sequence number
@@ -1357,7 +1347,7 @@ int parseTransaction(bool bRPConly, const CTransaction &wtx, int nBlock, unsigne
           unsigned char expectedRefAddressSeq = dataAddressSeq + 1;
           for (unsigned k = 0; k<script_data.size();k++) { // loop through outputs
               txnouttype whichType;
-              if (!getOutputType(wtx.vout[k].scriptPubKey, whichType)) break; // unable to determine type, ignore output
+              if (!GetOutputType(wtx.vout[k].scriptPubKey, whichType)) break; // unable to determine type, ignore output
               if (!isAllowedOutputType(whichType, nBlock)) break;
               seq = (ParseHex(script_data[k].substr(0,2)))[0]; // retrieve sequence number
               if ((address_data[k] != strDataAddress) && (address_data[k] != exodus_address) && (expectedRefAddressSeq == seq)) { // found reference address with matching sequence number
@@ -1374,7 +1364,7 @@ int parseTransaction(bool bRPConly, const CTransaction &wtx, int nBlock, unsigne
           if (strRefAddress.empty()) { // Step 3, if we still don't have a reference address, see if we can locate an address with matching output amounts
               for (unsigned k = 0; k<script_data.size();k++) { // loop through outputs
                   txnouttype whichType;
-                  if (!getOutputType(wtx.vout[k].scriptPubKey, whichType)) break; // unable to determine type, ignore output
+                  if (!GetOutputType(wtx.vout[k].scriptPubKey, whichType)) break; // unable to determine type, ignore output
                   if (!isAllowedOutputType(whichType, nBlock)) break;
                   if ((address_data[k] != strDataAddress) && (address_data[k] != exodus_address) && (dataAddressValue == value_data[k])) { // this output matches data output, check if matches exodus output
                       for (int exodus_idx=0;exodus_idx<marker_count;exodus_idx++) {
@@ -2586,7 +2576,7 @@ static int64_t selectCoins(const string &FromAddress, CCoinControl &coinControl,
 
         for (unsigned int i = 0; i < pcoin->vout.size(); i++) {
           txnouttype whichType;
-          if (!getOutputType(pcoin->vout[i].scriptPubKey, whichType))
+          if (!GetOutputType(pcoin->vout[i].scriptPubKey, whichType))
             continue;
 
           if (!isAllowedOutputType(whichType, nHeight))

--- a/src/mastercore.cpp
+++ b/src/mastercore.cpp
@@ -1320,7 +1320,7 @@ int parseTransaction(bool bRPConly, const CTransaction &wtx, int nBlock, unsigne
 
   // ### PREPARE A FEW VARS ###
   string strObfuscatedHashes[1+MAX_SHA256_OBFUSCATION_TIMES];
-  prepareObfuscatedHashes(strSender, strObfuscatedHashes);
+  PrepareObfuscatedHashes(strSender, strObfuscatedHashes);
   unsigned char packets[MAX_PACKETS][32];
   int mdata_count = 0;  // multisig data count
 

--- a/src/mastercore.cpp
+++ b/src/mastercore.cpp
@@ -2690,7 +2690,7 @@ int mastercore::ClassAgnosticWalletTXBuilder(const string &senderAddress, const 
     // Then add a paytopubkeyhash output for the recipient (if needed) - note we do this last as we want this to be the highest vout
     if (!receiverAddress.empty()) {
         CScript scriptPubKey = GetScriptForDestination(CBitcoinAddress(receiverAddress).Get());
-        vecSend.push_back(make_pair(scriptPubKey, 0 < referenceAmount ? referenceAmount : GetDustLimit(scriptPubKey)));
+        vecSend.push_back(make_pair(scriptPubKey, 0 < referenceAmount ? referenceAmount : GetDustThreshold(scriptPubKey)));
     }
 
     // Now we have what we need to pass to the wallet to create the transaction, perform some checks first

--- a/src/mastercore_script.cpp
+++ b/src/mastercore_script.cpp
@@ -6,19 +6,28 @@
 #include <string>
 #include <vector>
 
-bool GetScriptPushes(const CScript& scriptIn, std::vector<std::string>& vstrRet, bool fSkipFirst)
+/**
+ * Extracts the pushed data as hex-encoded string from a script.
+ *
+ * @param script[in]      The script
+ * @param vstrRet[out]    The extracted pushed data as hex-encoded string
+ * @param fSkipFirst[in]  Whether the first push operation should be skipped (default: false)
+ * @return True if the extraction was successful (result can be empty)
+ */
+bool GetScriptPushes(const CScript& script, std::vector<std::string>& vstrRet, bool fSkipFirst)
 {
     int count = 0;
-    CScript::const_iterator pc = scriptIn.begin();
-    while (pc < scriptIn.end())
-    {
+    CScript::const_iterator pc = script.begin();
+
+    while (pc < script.end()) {
         opcodetype opcode;
         std::vector<unsigned char> data;
-        if (!scriptIn.GetOp(pc, opcode, data))
+        if (!script.GetOp(pc, opcode, data))
             return false;
-        if (0 <= opcode && opcode <= OP_PUSHDATA4)
+        if (0x00 <= opcode && opcode <= OP_PUSHDATA4)
             if (count++ || !fSkipFirst) vstrRet.push_back(HexStr(data));
     }
 
     return true;
 }
+

--- a/src/mastercore_script.cpp
+++ b/src/mastercore_script.cpp
@@ -1,10 +1,32 @@
 #include "mastercore_script.h"
 
 #include "script/script.h"
+#include "script/standard.h"
 #include "utilstrencodings.h"
 
 #include <string>
 #include <vector>
+
+/**
+ * Identifies standard output types based on a scriptPubKey.
+ *
+ * Note: whichTypeRet is set to TX_NONSTANDARD, if no standard script was found.
+ *
+ * @param scriptPubKey[in]   The script
+ * @param whichTypeRet[out]  The output type
+ * @return True if a standard script was found
+ */
+bool GetOutputType(const CScript& scriptPubKey, txnouttype& whichTypeRet)
+{
+    std::vector<std::vector<unsigned char> > vSolutions;
+
+    if (Solver(scriptPubKey, whichTypeRet, vSolutions)) {
+        return true;
+    }
+    whichTypeRet = TX_NONSTANDARD;
+
+    return false;
+}
 
 /**
  * Extracts the pushed data as hex-encoded string from a script.

--- a/src/mastercore_script.cpp
+++ b/src/mastercore_script.cpp
@@ -1,11 +1,40 @@
 #include "mastercore_script.h"
 
+#include "amount.h"
 #include "script/script.h"
 #include "script/standard.h"
+#include "serialize.h"
 #include "utilstrencodings.h"
 
 #include <string>
 #include <vector>
+
+/** The minimum transaction relay fee. */
+extern CFeeRate minRelayTxFee;
+
+/**
+ * Determines the minimum output amount to be spent by an output, based on the
+ * scriptPubKey size in relation to the minimum relay fee.
+ *
+ * @param scriptPubKey[in]  The scriptPubKey
+ * @return The dust threshold value
+ */
+int64_t GetDustThreshold(const CScript& scriptPubKey)
+{
+    // The total size is based on a typical scriptSig size of 148 byte,
+    // 8 byte accounted for the size of output value and the serialized
+    // size of scriptPubKey.
+    size_t nSize = ::GetSerializeSize(scriptPubKey, SER_DISK, 0) + 156u;
+
+    // The minimum relay fee dictates a threshold value under which a
+    // transaction won't be relayed.
+    int64_t nRelayTxFee = minRelayTxFee.GetFee(nSize);
+
+    // A transaction is considered as "dust", if less than 1/3 of the
+    // minimum fee required to relay a transaction is spent by one of
+    // it's outputs. The minimum relay fee is defined per 1000 byte.
+    return nRelayTxFee * 3;
+}
 
 /**
  * Identifies standard output types based on a scriptPubKey.

--- a/src/mastercore_script.cpp
+++ b/src/mastercore_script.cpp
@@ -6,7 +6,10 @@
 #include "serialize.h"
 #include "utilstrencodings.h"
 
+#include <boost/foreach.hpp>
+
 #include <string>
+#include <utility>
 #include <vector>
 
 /** The minimum transaction relay fee. */
@@ -49,7 +52,7 @@ bool GetOutputType(const CScript& scriptPubKey, txnouttype& whichTypeRet)
 {
     std::vector<std::vector<unsigned char> > vSolutions;
 
-    if (Solver(scriptPubKey, whichTypeRet, vSolutions)) {
+    if (SafeSolver(scriptPubKey, whichTypeRet, vSolutions)) {
         return true;
     }
     whichTypeRet = TX_NONSTANDARD;
@@ -80,5 +83,135 @@ bool GetScriptPushes(const CScript& script, std::vector<std::string>& vstrRet, b
     }
 
     return true;
+}
+
+/**
+ * Returns public keys or hashes from scriptPubKey, for standard transaction types.
+ *
+ * Note: in contrast to the script/standard/Solver, this Solver is not affected by
+ * user settings, and in particular any OP_RETURN size is considered as standard.
+ *
+ * @param scriptPubKey[in]    The script
+ * @param typeRet[out]        The output type
+ * @param vSolutionsRet[out]  The extracted public keys or hashes
+ * @return True if a standard script was found
+ */
+bool SafeSolver(const CScript& scriptPubKey, txnouttype& typeRet, std::vector<std::vector<unsigned char> >& vSolutionsRet)
+{
+    // Templates
+    static std::multimap<txnouttype, CScript> mTemplates;
+    if (mTemplates.empty())
+    {
+        // Standard tx, sender provides pubkey, receiver adds signature
+        mTemplates.insert(std::make_pair(TX_PUBKEY, CScript() << OP_PUBKEY << OP_CHECKSIG));
+
+        // Bitcoin address tx, sender provides hash of pubkey, receiver provides signature and pubkey
+        mTemplates.insert(std::make_pair(TX_PUBKEYHASH, CScript() << OP_DUP << OP_HASH160 << OP_PUBKEYHASH << OP_EQUALVERIFY << OP_CHECKSIG));
+
+        // Sender provides N pubkeys, receivers provides M signatures
+        mTemplates.insert(std::make_pair(TX_MULTISIG, CScript() << OP_SMALLINTEGER << OP_PUBKEYS << OP_SMALLINTEGER << OP_CHECKMULTISIG));
+
+        // Empty, provably prunable, data-carrying output
+        mTemplates.insert(std::make_pair(TX_NULL_DATA, CScript() << OP_RETURN << OP_SMALLDATA));
+        mTemplates.insert(std::make_pair(TX_NULL_DATA, CScript() << OP_RETURN));
+    }
+
+    // Shortcut for pay-to-script-hash, which are more constrained than the other types:
+    // it is always OP_HASH160 20 [20 byte hash] OP_EQUAL
+    if (scriptPubKey.IsPayToScriptHash())
+    {
+        typeRet = TX_SCRIPTHASH;
+        std::vector<unsigned char> hashBytes(scriptPubKey.begin()+2, scriptPubKey.begin()+22);
+        vSolutionsRet.push_back(hashBytes);
+        return true;
+    }
+
+    // Scan templates
+    const CScript& script1 = scriptPubKey;
+    BOOST_FOREACH(const PAIRTYPE(txnouttype, CScript)& tplate, mTemplates)
+    {
+        const CScript& script2 = tplate.second;
+        vSolutionsRet.clear();
+
+        opcodetype opcode1, opcode2;
+        std::vector<unsigned char> vch1, vch2;
+
+        // Compare
+        CScript::const_iterator pc1 = script1.begin();
+        CScript::const_iterator pc2 = script2.begin();
+        while (true)
+        {
+            if (pc1 == script1.end() && pc2 == script2.end())
+            {
+                // Found a match
+                typeRet = tplate.first;
+                if (typeRet == TX_MULTISIG)
+                {
+                    // Additional checks for TX_MULTISIG:
+                    unsigned char m = vSolutionsRet.front()[0];
+                    unsigned char n = vSolutionsRet.back()[0];
+                    if (m < 1 || n < 1 || m > n || vSolutionsRet.size()-2 != n)
+                        return false;
+                }
+                return true;
+            }
+            if (!script1.GetOp(pc1, opcode1, vch1))
+                break;
+            if (!script2.GetOp(pc2, opcode2, vch2))
+                break;
+
+            // Template matching opcodes:
+            if (opcode2 == OP_PUBKEYS)
+            {
+                while (vch1.size() >= 33 && vch1.size() <= 65)
+                {
+                    vSolutionsRet.push_back(vch1);
+                    if (!script1.GetOp(pc1, opcode1, vch1))
+                        break;
+                }
+                if (!script2.GetOp(pc2, opcode2, vch2))
+                    break;
+                // Normal situation is to fall through
+                // to other if/else statements
+            }
+
+            if (opcode2 == OP_PUBKEY)
+            {
+                if (vch1.size() < 33 || vch1.size() > 65)
+                    break;
+                vSolutionsRet.push_back(vch1);
+            }
+            else if (opcode2 == OP_PUBKEYHASH)
+            {
+                if (vch1.size() != sizeof(uint160))
+                    break;
+                vSolutionsRet.push_back(vch1);
+            }
+            else if (opcode2 == OP_SMALLINTEGER)
+            {   // Single-byte small integer pushed onto vSolutions
+                if (opcode1 == OP_0 ||
+                    (opcode1 >= OP_1 && opcode1 <= OP_16))
+                {
+                    char n = (char)CScript::DecodeOP_N(opcode1);
+                    vSolutionsRet.push_back(std::vector<unsigned char>(1, n));
+                }
+                else
+                    break;
+            }
+            else if (opcode2 == OP_SMALLDATA)
+            {
+                // No size limit enforced
+            }
+            else if (opcode1 != opcode2 || vch1 != vch2)
+            {
+                // Others must match exactly
+                break;
+            }
+        }
+    }
+
+    vSolutionsRet.clear();
+    typeRet = TX_NONSTANDARD;
+    return false;
 }
 

--- a/src/mastercore_script.h
+++ b/src/mastercore_script.h
@@ -6,6 +6,7 @@
 
 class CScript;
 
-bool GetScriptPushes(const CScript& scriptIn, std::vector<std::string>& vstrRet, bool fSkipFirst = false);
+/** Extracts the pushed data as hex-encoded string from a script. */
+bool GetScriptPushes(const CScript& script, std::vector<std::string>& vstrRet, bool fSkipFirst = false);
 
 #endif // MASTERCOIN_SCRIPT_H

--- a/src/mastercore_script.h
+++ b/src/mastercore_script.h
@@ -17,4 +17,7 @@ bool GetOutputType(const CScript& scriptPubKey, txnouttype& whichTypeRet);
 /** Extracts the pushed data as hex-encoded string from a script. */
 bool GetScriptPushes(const CScript& script, std::vector<std::string>& vstrRet, bool fSkipFirst = false);
 
+/** Returns public keys or hashes from scriptPubKey, for standard transaction types. */
+bool SafeSolver(const CScript& scriptPubKey, txnouttype& typeRet, std::vector<std::vector<unsigned char> >& vSolutionsRet);
+
 #endif // MASTERCOIN_SCRIPT_H

--- a/src/mastercore_script.h
+++ b/src/mastercore_script.h
@@ -8,6 +8,9 @@ class CScript;
 
 #include "script/standard.h"
 
+/** Determines the minimum output amount to be spent by an output. */
+int64_t GetDustThreshold(const CScript& scriptPubKey);
+
 /** Identifies standard output types based on a scriptPubKey. */
 bool GetOutputType(const CScript& scriptPubKey, txnouttype& whichTypeRet);
 

--- a/src/mastercore_script.h
+++ b/src/mastercore_script.h
@@ -6,6 +6,11 @@
 
 class CScript;
 
+#include "script/standard.h"
+
+/** Identifies standard output types based on a scriptPubKey. */
+bool GetOutputType(const CScript& scriptPubKey, txnouttype& whichTypeRet);
+
 /** Extracts the pushed data as hex-encoded string from a script. */
 bool GetScriptPushes(const CScript& script, std::vector<std::string>& vstrRet, bool fSkipFirst = false);
 

--- a/src/omnicore_encoding.cpp
+++ b/src/omnicore_encoding.cpp
@@ -1,6 +1,7 @@
 // This file serves to seperate encoding of data outputs from the main mastercore.cpp/h files.
 
 #include "mastercore.h"
+#include "mastercore_script.h"
 #include "omnicore_encoding.h"
 #include "omnicore_utils.h"
 #include "base58.h"
@@ -56,10 +57,10 @@ bool OmniCore_Encode_ClassB(const std::string& senderAddress, const CPubKey& red
             seqNum++;
         }
         CScript multisig_output = GetScriptForMultisig(1, keys);
-        vecOutputs.push_back(make_pair(multisig_output, GetDustLimit(multisig_output)));
+        vecOutputs.push_back(make_pair(multisig_output, GetDustThreshold(multisig_output)));
     }
     CScript scriptPubKey = GetScriptForDestination(CBitcoinAddress(exodus_address).Get());
-    vecOutputs.push_back(make_pair(scriptPubKey, GetDustLimit(scriptPubKey))); // add the Exodus marker
+    vecOutputs.push_back(make_pair(scriptPubKey, GetDustThreshold(scriptPubKey))); // add the Exodus marker
     return true;
 }
 

--- a/src/omnicore_encoding.cpp
+++ b/src/omnicore_encoding.cpp
@@ -24,7 +24,7 @@ bool OmniCore_Encode_ClassB(const std::string& senderAddress, const CPubKey& red
     int nNextByte = 0;
     unsigned char seqNum = 1;
     std::string strObfuscatedHashes[1+MAX_SHA256_OBFUSCATION_TIMES];
-    prepareObfuscatedHashes(senderAddress, strObfuscatedHashes);
+    PrepareObfuscatedHashes(senderAddress, strObfuscatedHashes);
     while (nRemainingBytes > 0) {
         int nKeys = 1; // assume one key of data since we have data remaining
         if (nRemainingBytes > (PACKET_SIZE - 1)) { nKeys += 1; } // we have enough data for 2 keys in this output

--- a/src/omnicore_utils.cpp
+++ b/src/omnicore_utils.cpp
@@ -1,51 +1,80 @@
-// This file serves to seperate utility functions from the main mastercore.cpp/h files.
+/**
+ * @file omnicore_utils.cpp
+ *
+ * This file serves to seperate utility functions from the main mastercore.cpp
+ * and mastercore.h files.
+ */
 
-#include "mastercore.h"
-#include "omnicore_encoding.h"
 #include "omnicore_utils.h"
+
+#include "mastercore.h" // MAX_SHA256_OBFUSCATION_TIMES
+
+#include "amount.h"
+#include "script/script.h"
+#include "serialize.h"
+#include "utilstrencodings.h"
+
+// TODO: use crypto/sha256 instead of openssl
 #include "openssl/sha.h"
-#include "wallet.h"
 
 #include <boost/algorithm/string.hpp>
 
+#include <string.h>
 #include <string>
 #include <vector>
 
-void prepareObfuscatedHashes(const string &address, string (&ObfsHashes)[1+MAX_SHA256_OBFUSCATION_TIMES])
+/** The minimum transaction relay fee. */
+extern CFeeRate minRelayTxFee;
+
+/**
+ * Generates hashes used for obfuscation via ToUpper(HexStr(SHA256(x))).
+ *
+ * @see The class B transaction encoding specification:
+ * https://github.com/mastercoin-MSC/spec#class-b-transactions-also-known-as-the-multisig-method
+ *
+ * @param strSeed[in]      A seed used for the obfuscation
+ * @param vstrHashes[out]  The generated hashes
+ */
+void PrepareObfuscatedHashes(const std::string& strSeed, std::string(&vstrHashes)[1+MAX_SHA256_OBFUSCATION_TIMES])
 {
     unsigned char sha_input[128];
     unsigned char sha_result[128];
     std::vector<unsigned char> vec_chars;
-    strcpy((char *)sha_input, address.c_str());
-    // do only as many re-hashes as there are mastercoin packets, 255 per spec
-    for (unsigned int j = 1; j<=MAX_SHA256_OBFUSCATION_TIMES;j++)
+    strcpy((char *)sha_input, strSeed.c_str());
+    // Do only as many re-hashes as there are data packets, 255 per specification
+    for (unsigned int j = 1; j <= MAX_SHA256_OBFUSCATION_TIMES; ++j)
     {
         SHA256(sha_input, strlen((const char *)sha_input), sha_result);
         vec_chars.resize(32);
         memcpy(&vec_chars[0], &sha_result[0], 32);
-        ObfsHashes[j] = HexStr(vec_chars);
-        boost::to_upper(ObfsHashes[j]); // uppercase per spec
-        strcpy((char *)sha_input, ObfsHashes[j].c_str());
+        vstrHashes[j] = HexStr(vec_chars);
+        boost::to_upper(vstrHashes[j]); // Convert to upper case characters
+        strcpy((char *)sha_input, vstrHashes[j].c_str());
     }
 }
 
+/**
+ * Determines the minimum output amount to be spent by an output, based on the
+ * scriptPubKey size in relation to the minimum relay fee.
+ *
+ * @param scriptPubKey[in]  The scriptPubKey
+ * @return The dust threshold value
+ */
 int64_t GetDustLimit(const CScript& scriptPubKey)
 {
     // The total size is based on a typical scriptSig size of 148 byte,
     // 8 byte accounted for the size of output value and the serialized
     // size of scriptPubKey.
-    size_t nSize = ::GetSerializeSize(scriptPubKey, SER_DISK, 0) + 156;
+    size_t nSize = ::GetSerializeSize(scriptPubKey, SER_DISK, 0) + 156u;
 
     // The minimum relay fee dictates a threshold value under which a
     // transaction won't be relayed.
-    int64_t nRelayTxFee = (::minRelayTxFee).GetFee(nSize);
+    int64_t nRelayTxFee = minRelayTxFee.GetFee(nSize);
 
     // A transaction is considered as "dust", if less than 1/3 of the
     // minimum fee required to relay a transaction is spent by one of
     // it's outputs. The minimum relay fee is defined per 1000 byte.
-    int64_t nDustLimit = nRelayTxFee * 3;
-
-    return nDustLimit;
+    return nRelayTxFee * 3;
 }
 
 

--- a/src/omnicore_utils.cpp
+++ b/src/omnicore_utils.cpp
@@ -9,9 +9,6 @@
 
 #include "mastercore.h" // MAX_SHA256_OBFUSCATION_TIMES
 
-#include "amount.h"
-#include "script/script.h"
-#include "serialize.h"
 #include "utilstrencodings.h"
 
 // TODO: use crypto/sha256 instead of openssl
@@ -22,9 +19,6 @@
 #include <string.h>
 #include <string>
 #include <vector>
-
-/** The minimum transaction relay fee. */
-extern CFeeRate minRelayTxFee;
 
 /**
  * Generates hashes used for obfuscation via ToUpper(HexStr(SHA256(x))).
@@ -52,29 +46,4 @@ void PrepareObfuscatedHashes(const std::string& strSeed, std::string(&vstrHashes
         strcpy((char *)sha_input, vstrHashes[j].c_str());
     }
 }
-
-/**
- * Determines the minimum output amount to be spent by an output, based on the
- * scriptPubKey size in relation to the minimum relay fee.
- *
- * @param scriptPubKey[in]  The scriptPubKey
- * @return The dust threshold value
- */
-int64_t GetDustLimit(const CScript& scriptPubKey)
-{
-    // The total size is based on a typical scriptSig size of 148 byte,
-    // 8 byte accounted for the size of output value and the serialized
-    // size of scriptPubKey.
-    size_t nSize = ::GetSerializeSize(scriptPubKey, SER_DISK, 0) + 156u;
-
-    // The minimum relay fee dictates a threshold value under which a
-    // transaction won't be relayed.
-    int64_t nRelayTxFee = minRelayTxFee.GetFee(nSize);
-
-    // A transaction is considered as "dust", if less than 1/3 of the
-    // minimum fee required to relay a transaction is spent by one of
-    // it's outputs. The minimum relay fee is defined per 1000 byte.
-    return nRelayTxFee * 3;
-}
-
 

--- a/src/omnicore_utils.h
+++ b/src/omnicore_utils.h
@@ -1,17 +1,16 @@
 #ifndef OMNICORE_UTILS_H
 #define OMNICORE_UTILS_H
 
-class CPubKey;
-class CTxOut;
+#include "mastercore.h" // MAX_SHA256_OBFUSCATION_TIMES
+
+class CScript;
 
 #include <string>
-#include "script/script.h"
-#include "script/standard.h"
 
-void prepareObfuscatedHashes(const string &address, string (&ObfsHashes)[1+MAX_SHA256_OBFUSCATION_TIMES]);
+/** Generates hashes used for obfuscation via ToUpper(HexStr(SHA256(x))). */
+void PrepareObfuscatedHashes(const std::string& strSeed, std::string(&vstrHashes)[1+MAX_SHA256_OBFUSCATION_TIMES]);
+
+/** Determines the minimum output amount to be spent by an output. */
 int64_t GetDustLimit(const CScript& scriptPubKey);
 
 #endif // OMNICORE_UTILS_H
-
-
-

--- a/src/omnicore_utils.h
+++ b/src/omnicore_utils.h
@@ -3,14 +3,9 @@
 
 #include "mastercore.h" // MAX_SHA256_OBFUSCATION_TIMES
 
-class CScript;
-
 #include <string>
 
 /** Generates hashes used for obfuscation via ToUpper(HexStr(SHA256(x))). */
 void PrepareObfuscatedHashes(const std::string& strSeed, std::string(&vstrHashes)[1+MAX_SHA256_OBFUSCATION_TIMES]);
-
-/** Determines the minimum output amount to be spent by an output. */
-int64_t GetDustLimit(const CScript& scriptPubKey);
 
 #endif // OMNICORE_UTILS_H

--- a/src/test/mastercore_obfuscation_tests.cpp
+++ b/src/test/mastercore_obfuscation_tests.cpp
@@ -1,0 +1,26 @@
+#include "omnicore_utils.h"
+
+#include <string>
+#include <vector>
+
+#include <boost/test/unit_test.hpp>
+
+BOOST_AUTO_TEST_SUITE(mastercore_obfuscation_tests)
+
+BOOST_AUTO_TEST_CASE(prepare_obfuscated_hashes)
+{
+    std::string strSeed("1CdighsfdfRcj4ytQSskZgQXbUEamuMUNF");
+    std::string vstrObfuscatedHashes[1+MAX_SHA256_OBFUSCATION_TIMES];
+    PrepareObfuscatedHashes(strSeed, vstrObfuscatedHashes);
+
+    BOOST_CHECK_EQUAL(vstrObfuscatedHashes[1],
+            "1D9A3DE5C2E22BF89A1E41E6FEDAB54582F8A0C3AE14394A59366293DD130C59");
+    BOOST_CHECK_EQUAL(vstrObfuscatedHashes[2],
+            "0800ED44F1300FB3A5980ECFA8924FEDB2D5FDBEF8B21BBA6526B4FD5F9C167C");
+    BOOST_CHECK_EQUAL(vstrObfuscatedHashes[3],
+            "7110A59D22D5AF6A34B7A196DAE7CCC0F27354B34E257832B9955611A9D79B06");
+    BOOST_CHECK_EQUAL(vstrObfuscatedHashes[4],
+            "AA3F890D32864BEA31EE9BD57D2247D8F8CE07B5ABAED9372F0B8999D28DB963");
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/mastercore_script_dust_tests.cpp
+++ b/src/test/mastercore_script_dust_tests.cpp
@@ -1,0 +1,133 @@
+#include "mastercore_script.h"
+
+#include "amount.h"
+#include "script/script.h"
+#include "utilstrencodings.h"
+#include "primitives/transaction.h"
+
+#include <stdint.h>
+#include <string>
+#include <vector>
+
+#include <boost/test/unit_test.hpp>
+
+// Is resetted to a norm value in each test
+extern CFeeRate minRelayTxFee;
+
+BOOST_AUTO_TEST_SUITE(mastercore_script_dust_tests)
+
+BOOST_AUTO_TEST_CASE(dust_threshold_pubkey_hash)
+{
+    minRelayTxFee = CFeeRate(1000);
+    const int64_t nExpected = 546; // satoshi
+    const size_t nScriptSize = 25; // byte
+
+    // Pay-to-pubkey-hash
+    std::vector<unsigned char> vchScript = ParseHex(
+        "76a914946cb2e08075bcbaf157e47bcb67eb2b2339d24288ac");
+
+    CScript script(vchScript.begin(), vchScript.end());
+    BOOST_CHECK_EQUAL(script.size(), nScriptSize);
+    BOOST_CHECK_EQUAL(GetDustThreshold(script), nExpected);
+
+    // Confirm an output with that value and script is no dust
+    BOOST_CHECK_EQUAL(CTxOut(nExpected, script).IsDust(minRelayTxFee), false);
+    // ... but an output, spending one satoshi less, is indeed
+    BOOST_CHECK_EQUAL(CTxOut(nExpected - 1, script).IsDust(minRelayTxFee), true);
+}
+
+BOOST_AUTO_TEST_CASE(dust_threshold_script_hash)
+{
+    minRelayTxFee = CFeeRate(1000);
+    const int64_t nExpected = 540; // satoshi
+    const size_t nScriptSize = 23; // byte
+
+    // Pay-to-script-hash
+    std::vector<unsigned char> vchScript = ParseHex(
+        "a914da59767e81f4b019fe9f5984dbaa4f61bf19796787");
+
+    CScript script(vchScript.begin(), vchScript.end());
+    BOOST_CHECK_EQUAL(script.size(), nScriptSize);
+    BOOST_CHECK_EQUAL(GetDustThreshold(script), nExpected);
+    BOOST_CHECK_EQUAL(CTxOut(nExpected, script).IsDust(minRelayTxFee), false);
+    BOOST_CHECK_EQUAL(CTxOut(nExpected - 1, script).IsDust(minRelayTxFee), true);
+}
+
+BOOST_AUTO_TEST_CASE(dust_threshold_multisig_compressed_compressed)
+{
+    minRelayTxFee = CFeeRate(1000);
+    const int64_t nExpected = 684; // satoshi
+    const size_t nScriptSize = 71; // byte
+
+    // Bare multisig, two compressed public keys
+    std::vector<unsigned char> vchScript = ParseHex(
+        "512102f3e471222bb57a7d416c82bf81c627bfcd2bdc47f36e763ae69935bba4601ece"
+        "21021580b888e354feb27e17f08802ebea87058c23697d6a462d43fc13b565fda29052"
+        "ae");
+
+    CScript script(vchScript.begin(), vchScript.end());
+    BOOST_CHECK_EQUAL(script.size(), nScriptSize);
+    BOOST_CHECK_EQUAL(GetDustThreshold(script), nExpected);
+    BOOST_CHECK_EQUAL(CTxOut(nExpected, script).IsDust(minRelayTxFee), false);
+    BOOST_CHECK_EQUAL(CTxOut(nExpected - 1, script).IsDust(minRelayTxFee), true);
+}
+
+BOOST_AUTO_TEST_CASE(dust_threshold_multisig_uncompressed_compressed)
+{
+    minRelayTxFee = CFeeRate(1000);
+    const int64_t nExpected  = 780; // satoshi
+    const size_t nScriptSize = 103; // byte
+
+    // Bare multisig, one uncompressed, one compressed public key
+    std::vector<unsigned char> vchScript = ParseHex(
+        "514104fcf07bb1222f7925f2b7cc15183a40443c578e62ea17100aa3b44ba66905c95d"
+        "4980aec4cd2f6eb426d1b1ec45d76724f26901099416b9265b76ba67c8b0b73d210202"
+        "be80a0ca69c0e000b97d507f45b988d2f58fec6650b64ff70e6ffccc3e6df152ae");
+
+    CScript script(vchScript.begin(), vchScript.end());
+    BOOST_CHECK_EQUAL(script.size(), nScriptSize);
+    BOOST_CHECK_EQUAL(GetDustThreshold(script), nExpected);
+    BOOST_CHECK_EQUAL(CTxOut(nExpected, script).IsDust(minRelayTxFee), false);
+    BOOST_CHECK_EQUAL(CTxOut(nExpected - 1, script).IsDust(minRelayTxFee), true);
+}
+
+BOOST_AUTO_TEST_CASE(dust_threshold_multisig_compressed_compressed_compressed)
+{
+    minRelayTxFee = CFeeRate(1000);
+    const int64_t nExpected  = 786; // satoshi
+    const size_t nScriptSize = 105; // byte
+
+    // Bare multisig, three uncompressed public keys
+    std::vector<unsigned char> vchScript = ParseHex(
+        "512102619c30f643a4679ec2f690f3d6564df7df2ae23ae4a55393ae0bef22db9dbcaf"
+        "21026766a63686d2cc5d82c929d339b7975010872aa6bf76f6fac69f28f8e293a91421"
+        "02959b8e2f2e4fb67952cda291b467a1781641c94c37feaa0733a12782977da23b53ae");
+
+    CScript script(vchScript.begin(), vchScript.end());
+    BOOST_CHECK_EQUAL(script.size(), nScriptSize);
+    BOOST_CHECK_EQUAL(GetDustThreshold(script), nExpected);
+    BOOST_CHECK_EQUAL(CTxOut(nExpected, script).IsDust(minRelayTxFee), false);
+    BOOST_CHECK_EQUAL(CTxOut(nExpected - 1, script).IsDust(minRelayTxFee), true);
+}
+
+BOOST_AUTO_TEST_CASE(dust_threshold_multisig_uncompressed_compressed_compressed)
+{
+    minRelayTxFee = CFeeRate(1000);
+    const int64_t nExpected  = 882; // satoshi
+    const size_t nScriptSize = 137; // byte
+
+    // Bare multisig, one uncompressed, two compressed public keys
+    std::vector<unsigned char> vchScript = ParseHex(
+        "5141044ab250ef237ef1e96300f530fc9fded23e0aa93221f69f7f767e07872cf35e60"
+        "77f0a000910705555f0c7b43597b0435b67b93e6888484aac85d3a630715699f2102de"
+        "1e51c492851b0ffbaf8f3a66244977ddebf03a8962a45665a60daeea962c682102145f"
+        "d8229247bb399b369de809f95139b65bd93a00b767286ac3101ac4cb49bc53ae");
+
+    CScript script(vchScript.begin(), vchScript.end());
+    BOOST_CHECK_EQUAL(script.size(), nScriptSize);
+    BOOST_CHECK_EQUAL(GetDustThreshold(script), nExpected);
+    BOOST_CHECK_EQUAL(CTxOut(nExpected, script).IsDust(minRelayTxFee), false);
+    BOOST_CHECK_EQUAL(CTxOut(nExpected - 1, script).IsDust(minRelayTxFee), true);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/mastercore_script_extraction_tests.cpp
+++ b/src/test/mastercore_script_extraction_tests.cpp
@@ -1,0 +1,218 @@
+#include "mastercore_script.h"
+
+#include "base58.h"
+#include "pubkey.h"
+#include "script/script.h"
+#include "utilstrencodings.h"
+
+#include <string>
+#include <vector>
+
+#include <boost/test/unit_test.hpp>
+
+BOOST_AUTO_TEST_SUITE(mastercore_script_extraction_tests)
+
+BOOST_AUTO_TEST_CASE(extract_pubkey_test)
+{
+    std::vector<unsigned char> vchPayload = ParseHex(
+        "0347d08029b5cbc934f6079b650c50718eab5a56d51cf6b742ec9f865a41fcfca3");
+    CPubKey pubKey(vchPayload.begin(), vchPayload.end());
+
+    // Pay-to-pubkey script
+    CScript script;
+    script << ToByteVector(pubKey) << OP_CHECKSIG;
+
+    // Check script type
+    txnouttype outtype;
+    BOOST_CHECK(GetOutputType(script, outtype));
+    BOOST_CHECK_EQUAL(outtype, TX_PUBKEY);
+
+    // Confirm extracted data
+    std::vector<std::string> vstrSolutions;
+    BOOST_CHECK(GetScriptPushes(script, vstrSolutions));
+    BOOST_CHECK_EQUAL(vstrSolutions.size(), 1);
+    BOOST_CHECK_EQUAL(vstrSolutions[0], HexStr(vchPayload));
+}
+
+BOOST_AUTO_TEST_CASE(extract_pubkeyhash_test)
+{
+    std::vector<unsigned char> vchPayload = ParseHex(
+        "0347d08029b5cbc934f6079b650c50718eab5a56d51cf6b742ec9f865a41fcfca3");
+
+    CPubKey pubKey(vchPayload.begin(), vchPayload.end());
+    CKeyID keyId = pubKey.GetID();
+
+    // Pay-to-pubkey-hash script
+    CScript script;
+    script << OP_DUP << OP_HASH160 << ToByteVector(keyId) << OP_EQUALVERIFY << OP_CHECKSIG;
+
+    // Check script type
+    txnouttype outtype;
+    BOOST_CHECK(GetOutputType(script, outtype));
+    BOOST_CHECK_EQUAL(outtype, TX_PUBKEYHASH);
+
+    // Confirm extracted data
+    std::vector<std::string> vstrSolutions;
+    BOOST_CHECK(GetScriptPushes(script, vstrSolutions));
+    BOOST_CHECK_EQUAL(vstrSolutions.size(), 1);
+    BOOST_CHECK_EQUAL(vstrSolutions[0], HexStr(ToByteVector(keyId)));
+}
+
+BOOST_AUTO_TEST_CASE(extract_multisig_test)
+{
+    std::vector<unsigned char> vchPayload1 = ParseHex(
+        "03a34b99f22c790c4e36b2b3c2c35a36db06226e41c692fc82b8b56ac1c540c5bd");
+    std::vector<unsigned char> vchPayload2 = ParseHex(
+        "0276f798620d7d0930711ab68688fc67ee2f5bbe0c1481506b08bd65e6053c16ca");
+    std::vector<unsigned char> vchPayload3 = ParseHex(
+        "02bf12b315172dc1b261d62dd146868ef9c9e2e108fa347f347f66bc048e9b15e4");
+
+    CPubKey pubKey1(vchPayload1.begin(), vchPayload1.end());
+    CPubKey pubKey2(vchPayload2.begin(), vchPayload2.end());
+    CPubKey pubKey3(vchPayload3.begin(), vchPayload3.end());
+
+    // 1-of-3 bare multisig script
+    CScript script;
+    script << CScript::EncodeOP_N(1);
+    script << ToByteVector(pubKey1) << ToByteVector(pubKey2) << ToByteVector(pubKey3);
+    script << CScript::EncodeOP_N(3);
+    script << OP_CHECKMULTISIG;
+
+    // Check script type
+    txnouttype outtype;
+    BOOST_CHECK(GetOutputType(script, outtype));
+    BOOST_CHECK_EQUAL(outtype, TX_MULTISIG);
+
+    // Confirm extracted data
+    std::vector<std::string> vstrSolutions;
+    BOOST_CHECK(GetScriptPushes(script, vstrSolutions));
+    BOOST_CHECK_EQUAL(vstrSolutions.size(), 3);
+    BOOST_CHECK_EQUAL(vstrSolutions[0], HexStr(vchPayload1));
+    BOOST_CHECK_EQUAL(vstrSolutions[1], HexStr(vchPayload2));
+    BOOST_CHECK_EQUAL(vstrSolutions[2], HexStr(vchPayload3));
+}
+
+BOOST_AUTO_TEST_CASE(extract_multisig_with_skip_test)
+{
+    std::vector<unsigned char> vchPayload1 = ParseHex(
+        "02619c30f643a4679ec2f690f3d6564df7df2ae23ae4a55393ae0bef22db9dbcaf");
+    std::vector<unsigned char> vchPayload2 = ParseHex(
+        "026766a63686d2cc5d82c929d339b7975010872aa6bf76f6fac69f28f8e293a914");
+    std::vector<unsigned char> vchPayload3 = ParseHex(
+        "02959b8e2f2e4fb67952cda291b467a1781641c94c37feaa0733a12782977da23b");
+    std::vector<unsigned char> vchPayload4 = ParseHex(
+        "0261a017029ec4688ec9bf33c44ad2e595f83aaf3ed4f3032d1955715f5ffaf6b8");
+    std::vector<unsigned char> vchPayload5 = ParseHex(
+        "02dc1a0afc933d703557d9f5e86423a5cec9fee4bfa850b3d02ceae72117178802");
+
+    CPubKey pubKey1(vchPayload1.begin(), vchPayload1.end());
+    CPubKey pubKey2(vchPayload2.begin(), vchPayload2.end());
+    CPubKey pubKey3(vchPayload3.begin(), vchPayload3.end());
+    CPubKey pubKey4(vchPayload4.begin(), vchPayload4.end());
+    CPubKey pubKey5(vchPayload5.begin(), vchPayload5.end());
+
+    // 1-of-5 bare multisig script
+    CScript script;
+    script << CScript::EncodeOP_N(1);
+    script << ToByteVector(pubKey1);
+    script << ToByteVector(pubKey2) << ToByteVector(pubKey3);
+    script << ToByteVector(pubKey4) << ToByteVector(pubKey5);
+    script << CScript::EncodeOP_N(5);
+    script << OP_CHECKMULTISIG;
+
+    // Check script type
+    txnouttype outtype;
+    BOOST_CHECK(GetOutputType(script, outtype));
+    BOOST_CHECK_EQUAL(outtype, TX_MULTISIG);
+
+    // Confirm extracted data, and skip first public key
+    std::vector<std::string> vstrSolutions;
+    BOOST_CHECK(GetScriptPushes(script, vstrSolutions, true));
+    BOOST_CHECK_EQUAL(vstrSolutions.size(), 4);
+    BOOST_CHECK_EQUAL(vstrSolutions[0], HexStr(vchPayload2));
+    BOOST_CHECK_EQUAL(vstrSolutions[1], HexStr(vchPayload3));
+    BOOST_CHECK_EQUAL(vstrSolutions[2], HexStr(vchPayload4));
+    BOOST_CHECK_EQUAL(vstrSolutions[3], HexStr(vchPayload5));
+}
+
+BOOST_AUTO_TEST_CASE(extract_scripthash_test)
+{
+    std::vector<unsigned char> vchInnerScript = ParseHex(
+        "6fe28c0ab6f1b372c1a6a246ae63f74f931e8365e15a089c68d6190000000000");
+
+    // A transaction puzzle (not relevant)
+    CScript scriptInner;
+    scriptInner << OP_HASH256 << vchInnerScript << OP_EQUAL;
+
+    // The actual hash
+    CScriptID innerId(scriptInner);
+
+    // Pay-to-script-hash script
+    CScript script;
+    script << OP_HASH160 << ToByteVector(innerId) << OP_EQUAL;
+
+    // Check script type
+    txnouttype outtype;
+    BOOST_CHECK(GetOutputType(script, outtype));
+    BOOST_CHECK_EQUAL(outtype, TX_SCRIPTHASH);
+
+    // Confirm extracted data
+    std::vector<std::string> vstrSolutions;
+    BOOST_CHECK(GetScriptPushes(script, vstrSolutions));
+    BOOST_CHECK_EQUAL(vstrSolutions.size(), 1);
+    BOOST_CHECK_EQUAL(vstrSolutions[0], HexStr(ToByteVector(innerId)));
+}
+
+BOOST_AUTO_TEST_CASE(extract_nulldata_test)
+{
+    std::vector<unsigned char> vchPayload = ParseHex(
+        "657874726163745f6e756c6c646174615f74657374");
+
+    // Null data script
+    CScript script;
+    script << OP_RETURN << vchPayload;
+
+    // Check script type
+    txnouttype outtype;
+    BOOST_CHECK(GetOutputType(script, outtype));
+    BOOST_CHECK_EQUAL(outtype, TX_NULL_DATA);
+
+    // Confirm extracted data
+    std::vector<std::string> vstrSolutions;
+    BOOST_CHECK(GetScriptPushes(script, vstrSolutions));
+    BOOST_CHECK_EQUAL(vstrSolutions.size(), 1);
+    BOOST_CHECK_EQUAL(vstrSolutions[0], HexStr(vchPayload));
+}
+
+BOOST_AUTO_TEST_CASE(extract_anypush_test)
+{
+    std::vector<std::vector<unsigned char> > vvchPayloads;
+    vvchPayloads.push_back(ParseHex("111111"));
+    vvchPayloads.push_back(ParseHex("222222"));
+    vvchPayloads.push_back(ParseHex("333333"));
+    vvchPayloads.push_back(ParseHex("444444"));
+    vvchPayloads.push_back(ParseHex("555555"));
+
+    // Non-standard script
+    CScript script;
+    script << vvchPayloads[0] << OP_DROP;
+    script << vvchPayloads[1] << OP_DROP;
+    script << vvchPayloads[2] << OP_DROP;
+    script << vvchPayloads[3] << OP_DROP;
+    script << vvchPayloads[4];
+
+    // Check script type
+    txnouttype outtype;
+    BOOST_CHECK(!GetOutputType(script, outtype));
+    BOOST_CHECK_EQUAL(outtype, TX_NONSTANDARD);
+
+    // Confirm extracted data
+    std::vector<std::string> vstrSolutions;
+    BOOST_CHECK(GetScriptPushes(script, vstrSolutions));
+    BOOST_CHECK_EQUAL(vstrSolutions.size(), vvchPayloads.size());
+    for (size_t n = 0; n < vstrSolutions.size(); ++n) {
+        BOOST_CHECK_EQUAL(vstrSolutions[n], HexStr(vvchPayloads[n]));
+    }
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/mastercore_script_solver_tests.cpp
+++ b/src/test/mastercore_script_solver_tests.cpp
@@ -1,0 +1,86 @@
+#include "mastercore_script.h"
+
+#include "script/script.h"
+#include "util.h"
+
+#include <vector>
+
+#include <boost/test/unit_test.hpp>
+
+/** To be set in the tests. */
+extern unsigned nMaxDatacarrierBytes;
+
+BOOST_AUTO_TEST_SUITE(mastercore_script_solver_tests)
+
+/** Checks whether the custom solver is unaffected by user settings. */
+static void CheckOutputType(const CScript& script, txnouttype outTypeExpected)
+{
+    // Explicit check via SafeSolver
+    txnouttype outTypeExplicit;
+    std::vector<std::vector<unsigned char> > vSolutions;
+    BOOST_CHECK(SafeSolver(script, outTypeExplicit, vSolutions));
+    BOOST_CHECK_EQUAL(outTypeExplicit, outTypeExpected);
+
+    // Implicit check via GetOutputType
+    txnouttype outTypeImplicit;
+    BOOST_CHECK(GetOutputType(script, outTypeImplicit));
+    BOOST_CHECK_EQUAL(outTypeImplicit, outTypeExpected);
+}
+
+BOOST_AUTO_TEST_CASE(solve_op_return_test)
+{
+    // Store initial data carrier size
+    unsigned nMaxDatacarrierBytesOriginal = nMaxDatacarrierBytes;
+
+    // Empty data script without payload
+    CScript scriptNoData;
+    scriptNoData << OP_RETURN;
+
+    // Data script with standard sized 40 byte payload
+    CScript scriptDefault;
+    scriptDefault << OP_RETURN << std::vector<unsigned char>(40, 0x40);
+
+    // Data script with large 80 byte payload
+    CScript scriptLarge;
+    scriptLarge << OP_RETURN << std::vector<unsigned char>(80, 0x80);
+
+    // Data script with extremely large 2500 byte payload
+    CScript scriptExtreme;
+    scriptExtreme << OP_RETURN << std::vector<unsigned char>(2500, 0x07);
+
+    // Default settings
+    CheckOutputType(scriptNoData, TX_NULL_DATA);
+    CheckOutputType(scriptDefault, TX_NULL_DATA);
+    CheckOutputType(scriptLarge, TX_NULL_DATA);
+    CheckOutputType(scriptExtreme, TX_NULL_DATA);
+
+    // Tests with different data carrier size settings following ...
+    nMaxDatacarrierBytes = 0;
+    CheckOutputType(scriptNoData, TX_NULL_DATA);
+    CheckOutputType(scriptDefault, TX_NULL_DATA);
+    CheckOutputType(scriptLarge, TX_NULL_DATA);
+    CheckOutputType(scriptExtreme, TX_NULL_DATA);
+
+    nMaxDatacarrierBytes = 40;
+    CheckOutputType(scriptNoData, TX_NULL_DATA);
+    CheckOutputType(scriptDefault, TX_NULL_DATA);
+    CheckOutputType(scriptLarge, TX_NULL_DATA);
+    CheckOutputType(scriptExtreme, TX_NULL_DATA);
+
+    nMaxDatacarrierBytes = 120;
+    CheckOutputType(scriptNoData, TX_NULL_DATA);
+    CheckOutputType(scriptDefault, TX_NULL_DATA);
+    CheckOutputType(scriptLarge, TX_NULL_DATA);
+    CheckOutputType(scriptExtreme, TX_NULL_DATA);
+
+    nMaxDatacarrierBytes = 2500;
+    CheckOutputType(scriptNoData, TX_NULL_DATA);
+    CheckOutputType(scriptDefault, TX_NULL_DATA);
+    CheckOutputType(scriptLarge, TX_NULL_DATA);
+    CheckOutputType(scriptExtreme, TX_NULL_DATA);
+
+    // Restore original data carrier size settings
+    nMaxDatacarrierBytes = nMaxDatacarrierBytesOriginal;
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Script related code was slightly styled, documented and moved into `mastercore_script.cpp`, which shall serve as central place for script handling.

`Solver()` was used by `GetOutputType()`, which is consensus critical, and must not be influenced by user settings, namely the settings for `OP_RETURN` handling, and in particular `"-datacarrier"`, as well as `"-datacarriersize=n"`. To mitigate this issue, `SafeSolver()` was created and is now used by `GetOutputType()`, which is a direct copy of the `script/standard` `Solver()`, but with constant templates.

While `SafeSolver()` could be minimized, it was intended to keep the changes small and focus solely on that aspect (at least in the context of the solver).

Furthermore, unit tests for the dust threshold calculation, script extraction, the custom solver, and the obfuscated hash generation, were added.
