### PR TITLE
Replace global balance arrays with std::map

### DIFF
--- a/src/mastercore.cpp
+++ b/src/mastercore.cpp
@@ -107,10 +107,14 @@ static const int nBlockTop = 0;
 static int nWaterlineBlock = 0;  //
 
 uint64_t global_metadex_market;
-uint64_t global_balance_money_maineco[100000];
-uint64_t global_balance_reserved_maineco[100000];
-uint64_t global_balance_money_testeco[100000];
-uint64_t global_balance_reserved_testeco[100000];
+//! Available balances of wallet properties in the main ecosystem
+std::map<uint32_t, int64_t> global_balance_money_maineco;
+//! Reserved balances of wallet properties in the main ecosystem
+std::map<uint32_t, int64_t> global_balance_reserved_maineco;
+//! Available balances of wallet properties in the test ecosystem
+std::map<uint32_t, int64_t> global_balance_money_testeco;
+//! Reserved balances of wallet properties in the test ecosystem
+std::map<uint32_t, int64_t> global_balance_reserved_testeco;
 
 /**
  * Used to indicate, whether to automatically commit created transactions.

--- a/src/mastercore.h
+++ b/src/mastercore.h
@@ -397,13 +397,15 @@ public:
  
 };
 
-//temp - only supporting 100,000 properties per eco here, research best way to expand array
-//these 4 arrays use about 3MB total memory with 100K properties limit (100000*8*4 bytes)
 extern uint64_t global_metadex_market;
-extern uint64_t global_balance_money_maineco[100000];
-extern uint64_t global_balance_reserved_maineco[100000];
-extern uint64_t global_balance_money_testeco[100000];
-extern uint64_t global_balance_reserved_testeco[100000];
+//! Available balances of wallet properties in the main ecosystem
+extern std::map<uint32_t, int64_t> global_balance_money_maineco;
+//! Reserved balances of wallet properties in the main ecosystem
+extern std::map<uint32_t, int64_t> global_balance_reserved_maineco;
+//! Available balances of wallet properties in the test ecosystem
+extern std::map<uint32_t, int64_t> global_balance_money_testeco;
+//! Reserved balances of wallet properties in the test ecosystem
+extern std::map<uint32_t, int64_t> global_balance_reserved_testeco;
 
 int64_t getMPbalance(const string &Address, unsigned int property, TallyType ttype);
 int64_t getUserAvailableMPbalance(const string &Address, unsigned int property);

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -61,11 +61,6 @@
 #define DECORATION_SIZE 64
 #define NUM_ITEMS 6 // 3 - number of recent transactions to display
 
-  extern uint64_t global_balance_money_maineco[100000];
-  extern uint64_t global_balance_reserved_maineco[100000];
-  extern uint64_t global_balance_money_testeco[100000];
-  extern uint64_t global_balance_reserved_testeco[100000];
-
 class TxViewDelegate : public QAbstractItemDelegate
 {
     Q_OBJECT


### PR DESCRIPTION
This is a resubmission of https://github.com/mastercoin-MSC/mastercore/pull/258.
1. Doesn't cover full range of potential properties, can result in out-of-bounds violation
2. No need to reserve 100000 elements each
3. [] operator reads an element at position, if key exists, or inserts an element, if not
4. Balances are int64_t
