### PR TITLE
Initialize log levels explicitly and support user defined file

### DIFF
--- a/src/omnicore/dex.cpp
+++ b/src/omnicore/dex.cpp
@@ -46,7 +46,7 @@ OfferMap::iterator my_it = my_offers.find(combo);
 // TODO: locks are needed around map's insert & erase
 CMPOffer *mastercore::DEx_getOffer(const string &seller_addr, unsigned int prop)
 {
-  if (msc_debug_dex) file_log("%s(%s, %u)\n", __FUNCTION__, seller_addr, prop);
+  if (msc_debug_dex) PrintToLog("%s(%s, %u)\n", __FUNCTION__, seller_addr, prop);
 const string combo = STR_SELLOFFER_ADDR_PROP_COMBO(seller_addr);
 OfferMap::iterator my_it = my_offers.find(combo);
 
@@ -58,7 +58,7 @@ OfferMap::iterator my_it = my_offers.find(combo);
 // TODO: locks are needed around map's insert & erase
 CMPAccept *mastercore::DEx_getAccept(const string &seller_addr, unsigned int prop, const string &buyer_addr)
 {
-  if (msc_debug_dex) file_log("%s(%s, %u, %s)\n", __FUNCTION__, seller_addr, prop, buyer_addr);
+  if (msc_debug_dex) PrintToLog("%s(%s, %u, %s)\n", __FUNCTION__, seller_addr, prop, buyer_addr);
 const string combo = STR_ACCEPT_ADDR_PROP_ADDR_COMBO(seller_addr, buyer_addr);
 AcceptMap::iterator my_it = my_accepts.find(combo);
 
@@ -80,7 +80,7 @@ int rc = DEX_ERROR_SELLOFFER;
   const string combo = STR_SELLOFFER_ADDR_PROP_COMBO(seller_addr);
 
   if (msc_debug_dex)
-   file_log("%s(%s|%s), nValue=%lu)\n", __FUNCTION__, seller_addr, combo, nValue);
+   PrintToLog("%s(%s|%s), nValue=%lu)\n", __FUNCTION__, seller_addr, combo, nValue);
 
   const uint64_t balanceReallyAvailable = getMPbalance(seller_addr, prop, BALANCE);
 
@@ -134,7 +134,7 @@ const uint64_t amount = getMPbalance(seller_addr, prop, SELLOFFER_RESERVE);
   my_offers.erase(my_it);
 
   if (msc_debug_dex)
-   file_log("%s(%s|%s)\n", __FUNCTION__, seller_addr, combo);
+   PrintToLog("%s(%s|%s)\n", __FUNCTION__, seller_addr, combo);
 
   return 0;
 }
@@ -144,7 +144,7 @@ int mastercore::DEx_offerUpdate(const string &seller_addr, unsigned int prop, ui
 {
 int rc = DEX_ERROR_SELLOFFER;
 
-  file_log("%s(%s, %d)\n", __FUNCTION__, seller_addr, prop);
+  PrintToLog("%s(%s, %d)\n", __FUNCTION__, seller_addr, prop);
 
   if (!DEx_offerExists(seller_addr, prop)) return (DEX_ERROR_SELLOFFER -12); // offer does not exist
 
@@ -173,21 +173,21 @@ uint64_t nActualAmount = getMPbalance(seller, prop, SELLOFFER_RESERVE);
 
   CMPOffer &offer = my_it->second;
 
-  if (msc_debug_dex) file_log("%s(offer: %s)\n", __FUNCTION__, offer.getHash().GetHex());
+  if (msc_debug_dex) PrintToLog("%s(offer: %s)\n", __FUNCTION__, offer.getHash().GetHex());
 
   // here we ensure the correct BTC fee was paid in this acceptance message, per spec
   if (fee_paid < offer.getMinFee())
   {
-    file_log("ERROR: fee too small -- the ACCEPT is rejected! (%lu is smaller than %lu)\n", fee_paid, offer.getMinFee());
+    PrintToLog("ERROR: fee too small -- the ACCEPT is rejected! (%lu is smaller than %lu)\n", fee_paid, offer.getMinFee());
     return DEX_ERROR_ACCEPT -105;
   }
 
-  file_log("%s(%s) OFFER FOUND\n", __FUNCTION__, selloffer_combo);
+  PrintToLog("%s(%s) OFFER FOUND\n", __FUNCTION__, selloffer_combo);
 
   // the older accept is the valid one: do not accept any new ones!
   if (DEx_getAccept(seller, prop, buyer))
   {
-    file_log("%s() ERROR: an accept from this same seller for this same offer is already open !!!!!\n", __FUNCTION__);
+    PrintToLog("%s() ERROR: an accept from this same seller for this same offer is already open !!!!!\n", __FUNCTION__);
     return DEX_ERROR_ACCEPT -205;
   }
 
@@ -237,7 +237,7 @@ const string accept_combo = STR_ACCEPT_ADDR_PROP_ADDR_COMBO(seller, buyer);
   }
   else
   {
-    file_log("%s() HASHES: offer=%s, accept=%s\n", __FUNCTION__, p_offer->getHash().GetHex(), p_accept->getHash().GetHex());
+    PrintToLog("%s() HASHES: offer=%s, accept=%s\n", __FUNCTION__, p_offer->getHash().GetHex(), p_accept->getHash().GetHex());
 
     // offer exists, determine whether it's the original offer or some random new one
     if (p_offer->getHash() == p_accept->getHash())
@@ -299,7 +299,7 @@ p_accept = DEx_getAccept(seller, prop, buyer);
     p_accept = DEx_getAccept(seller, prop, buyer); 
   }
 
-  if (msc_debug_dex) file_log("%s(%s, %s)\n", __FUNCTION__, seller, buyer);
+  if (msc_debug_dex) PrintToLog("%s(%s, %s)\n", __FUNCTION__, seller, buyer);
 
   if (!p_accept) return (DEX_ERROR_PAYMENT -1);  // there must be an active Accept for this payment
 
@@ -316,7 +316,7 @@ p_accept = DEx_getAccept(seller, prop, buyer);
   const uint64_t nActualAmount = p_accept->getAcceptAmountRemaining();  // actual amount desired, in the Accept
 
   if (msc_debug_dex)
-   file_log("BTC_desired= %30.20lf , offer_amount=%30.20lf , perc_X= %30.20lf , Purchased= %30.20lf , units_purchased= %lu\n",
+   PrintToLog("BTC_desired= %30.20lf , offer_amount=%30.20lf , perc_X= %30.20lf , Purchased= %30.20lf , units_purchased= %lu\n",
    BTC_desired_original, offer_amount_original, perc_X, Purchased, units_purchased);
 
   // if units_purchased is greater than what's in the Accept, the buyer gets only what's in the Accept
@@ -334,7 +334,7 @@ p_accept = DEx_getAccept(seller, prop, buyer);
       bool bValid = true;
       p_txlistdb->recordPaymentTX(txid, bValid, blockNow, vout, prop, units_purchased, buyer, seller);
 
-      file_log("#######################################################\n");
+      PrintToLog("#######################################################\n");
   }
 
   // reduce the amount of units still desired by the buyer and if 0 must destroy the Accept
@@ -369,7 +369,7 @@ AcceptMap::iterator my_it = my_accepts.begin();
 
     if ((blockNow - mpaccept.block) >= (int) mpaccept.getBlockTimeLimit())
     {
-      file_log("%s() FOUND EXPIRED ACCEPT, erasing: blockNow=%d, offer block=%d, blocktimelimit= %d\n",
+      PrintToLog("%s() FOUND EXPIRED ACCEPT, erasing: blockNow=%d, offer block=%d, blocktimelimit= %d\n",
        __FUNCTION__, blockNow, mpaccept.block, mpaccept.getBlockTimeLimit());
 
       // extract the seller, buyer & property from the Key

--- a/src/omnicore/dex.h
+++ b/src/omnicore/dex.h
@@ -62,7 +62,7 @@ public:
       : offerBlock(b), offer_amount_original(a), property(cu), BTC_desired_original(d), min_fee(fee), blocktimelimit(btl),
         txid(tx), subaction(0)
   {
-    if (msc_debug_dex) file_log("%s(%lu): %s , line %d, file: %s\n", __FUNCTION__, a, txid.GetHex(), __LINE__, __FILE__);
+    if (msc_debug_dex) PrintToLog("%s(%lu): %s , line %d, file: %s\n", __FUNCTION__, a, txid.GetHex(), __LINE__, __FILE__);
   }
 
   void Set(uint64_t d, uint64_t fee, unsigned char btl, unsigned char suba)
@@ -128,24 +128,24 @@ public:
    offer_amount_original(o), BTC_desired_original(btc),offer_txid(txid),block(b)
   {
     accept_amount_original = accept_amount_remaining;
-    file_log("%s(%lu), line %d, file: %s\n", __FUNCTION__, a, __LINE__, __FILE__);
+    PrintToLog("%s(%lu), line %d, file: %s\n", __FUNCTION__, a, __LINE__, __FILE__);
   }
 
   CMPAccept(uint64_t origA, uint64_t remA, int b, unsigned char blt, unsigned int c, uint64_t o, uint64_t btc, const uint256 &txid):accept_amount_original(origA),accept_amount_remaining(remA),blocktimelimit(blt),property(c),
    offer_amount_original(o), BTC_desired_original(btc),offer_txid(txid),block(b)
   {
-    file_log("%s(%lu[%lu]), line %d, file: %s\n", __FUNCTION__, remA, origA, __LINE__, __FILE__);
+    PrintToLog("%s(%lu[%lu]), line %d, file: %s\n", __FUNCTION__, remA, origA, __LINE__, __FILE__);
   }
 
   void print()
   {
-    file_log("buying: %12.8lf (originally= %12.8lf) in block# %d\n",
+    PrintToLog("buying: %12.8lf (originally= %12.8lf) in block# %d\n",
      (double)accept_amount_remaining/(double)COIN, (double)accept_amount_original/(double)COIN, block);
   }
 
   uint64_t getAcceptAmountRemaining() const
   { 
-    file_log("%s(); buyer still wants = %lu, line %d, file: %s\n", __FUNCTION__, accept_amount_remaining, __LINE__, __FILE__);
+    PrintToLog("%s(); buyer still wants = %lu, line %d, file: %s\n", __FUNCTION__, accept_amount_remaining, __LINE__, __FILE__);
 
     return accept_amount_remaining;
   }

--- a/src/omnicore/log.cpp
+++ b/src/omnicore/log.cpp
@@ -79,7 +79,12 @@ static void DebugLogInit()
 
     boost::filesystem::path pathDebug = GetDataDir() / LOG_FILENAME;
     fileout = fopen(pathDebug.string().c_str(), "a");
-    if (fileout) setbuf(fileout, NULL); // Unbuffered
+
+    if (fileout) {
+        setbuf(fileout, NULL); // Unbuffered
+    } else {
+        PrintToConsole("Failed to open debug log file: %s\n", pathDebug.string());
+    }
 
     mutexDebugLog = new boost::mutex();
 

--- a/src/omnicore/log.cpp
+++ b/src/omnicore/log.cpp
@@ -241,6 +241,77 @@ int ConsolePrint(const std::string& str)
 }
 
 /**
+ * Determine whether to override compiled debug levels via enumerating startup option --omnidebug.
+ *
+ * Example usage (granular categories)    : --omnidebug=parser --omnidebug=metadex1 --omnidebug=ui
+ * Example usage (enable all categories)  : --omnidebug=all
+ * Example usage (disable all debugging)  : --omnidebug=none
+ * Example usage (disable all except XYZ) : --omnidebug=none --omnidebug=parser --omnidebug=sto
+ */
+void InitDebugLogLevels()
+{
+    if (!mapArgs.count("-omnidebug")) {
+        return;
+    }
+
+    const std::vector<std::string>& debugLevels = mapMultiArgs["-omnidebug"];
+    if (!debugLevels.empty()) {
+        for (std::vector<std::string>::const_iterator it = debugLevels.begin(); it != debugLevels.end(); ++it) {
+            if (*it == "parser_data") msc_debug_parser_data = true;
+            if (*it == "parser") msc_debug_parser = true;
+            if (*it == "verbose") msc_debug_verbose = true;
+            if (*it == "verbose2") msc_debug_verbose2 = true;
+            if (*it == "verbose3") msc_debug_verbose3 = true;
+            if (*it == "vin") msc_debug_vin = true;
+            if (*it == "script") msc_debug_script = true;
+            if (*it == "dex") msc_debug_dex = true;
+            if (*it == "send") msc_debug_send = true;
+            if (*it == "tokens") msc_debug_tokens = true;
+            if (*it == "spec") msc_debug_spec = true;
+            if (*it == "exo") msc_debug_exo = true;
+            if (*it == "tally") msc_debug_tally = true;
+            if (*it == "sp") msc_debug_sp = true;
+            if (*it == "sto") msc_debug_sto = true;
+            if (*it == "txdb") msc_debug_txdb = true;
+            if (*it == "tradedb") msc_debug_tradedb = true;
+            if (*it == "persistence") msc_debug_persistence = true;
+            if (*it == "ui") msc_debug_ui = true;
+            if (*it == "pending") msc_debug_pending = true;
+            if (*it == "metadex1") msc_debug_metadex1 = true;
+            if (*it == "metadex2") msc_debug_metadex2 = true;
+            if (*it == "metadex3") msc_debug_metadex3 = true;
+            if (*it == "none" || *it == "all") {
+                bool allDebugState = false;
+                if (*it == "all") allDebugState = true;
+                msc_debug_parser_data = allDebugState;
+                msc_debug_parser = allDebugState;
+                msc_debug_verbose = allDebugState;
+                msc_debug_verbose2 = allDebugState;
+                msc_debug_verbose3 = allDebugState;
+                msc_debug_vin = allDebugState;
+                msc_debug_script = allDebugState;
+                msc_debug_dex = allDebugState;
+                msc_debug_send = allDebugState;
+                msc_debug_tokens = allDebugState;
+                msc_debug_spec = allDebugState;
+                msc_debug_exo = allDebugState;
+                msc_debug_tally = allDebugState;
+                msc_debug_sp = allDebugState;
+                msc_debug_sto = allDebugState;
+                msc_debug_txdb = allDebugState;
+                msc_debug_tradedb = allDebugState;
+                msc_debug_persistence = allDebugState;
+                msc_debug_ui = allDebugState;
+                msc_debug_pending = allDebugState;
+                msc_debug_metadex1 = allDebugState;
+                msc_debug_metadex2 = allDebugState;
+                msc_debug_metadex3 = allDebugState;
+            }
+        }
+    }
+}
+
+/**
  * Scrolls debug log, if it's getting too big.
  */
 void ShrinkDebugLog()

--- a/src/omnicore/log.cpp
+++ b/src/omnicore/log.cpp
@@ -14,8 +14,8 @@
 #include <string>
 #include <vector>
 
-// Log files
-const std::string LOG_FILENAME    = "mastercore.log";
+// Default log files
+const std::string LOG_FILENAME    = "omnicore.log";
 const std::string INFO_FILENAME   = "mastercore_crowdsales.log";
 const std::string OWNERS_FILENAME = "mastercore_owners.log";
 
@@ -70,6 +70,27 @@ static boost::mutex* mutexDebugLog = NULL;
 extern volatile bool fReopenOmniCoreLog;
 
 /**
+ * Returns path for debug log file.
+ *
+ * The log file can be specified via startup option "--omnilogfile=/path/to/omnicore.log",
+ * and if none is provided, then the client's datadir is used as default location.
+ */
+static boost::filesystem::path GetLogPath()
+{
+    boost::filesystem::path pathLogFile;
+    std::string strLogPath = GetArg("-omnilogfile", "");
+
+    if (!strLogPath.empty()) {
+        pathLogFile = boost::filesystem::path(strLogPath);
+        TryCreateDirectory(pathLogFile.parent_path());
+    } else {
+        pathLogFile = GetDataDir() / LOG_FILENAME;
+    }
+
+    return pathLogFile;
+}
+
+/**
  * Opens debug log file.
  */
 static void DebugLogInit()
@@ -77,7 +98,7 @@ static void DebugLogInit()
     assert(fileout == NULL);
     assert(mutexDebugLog == NULL);
 
-    boost::filesystem::path pathDebug = GetDataDir() / LOG_FILENAME;
+    boost::filesystem::path pathDebug = GetLogPath();
     fileout = fopen(pathDebug.string().c_str(), "a");
 
     if (fileout) {
@@ -87,68 +108,6 @@ static void DebugLogInit()
     }
 
     mutexDebugLog = new boost::mutex();
-
-    // when providing support recompiling to enable debug levels is not always feasible
-    // determine whether to override compiled debug levels via enumerating startup option --omnidebug
-    // example usage (granular categories)    : --omnidebug=parser --omnidebug=metadex1 --omnidebug=ui
-    // example usage (enable all categories)  : --omnidebug=all
-    // example usage (disable all debugging)  : --omnidebug=none
-    // example usage (disable all except XYZ) : --omnidebug=none --omnidebug=parser --omnidebug=sto
-    if (!mapMultiArgs["-omnidebug"].empty()) {
-        const std::vector<std::string>& debugLevels = mapMultiArgs["-omnidebug"];
-        for (std::vector<std::string>::const_iterator it = debugLevels.begin(); it != debugLevels.end(); ++it) {
-            if (*it == "parser_data") msc_debug_parser_data = true;
-            if (*it == "parser") msc_debug_parser = true;
-            if (*it == "verbose") msc_debug_verbose = true;
-            if (*it == "verbose2") msc_debug_verbose2 = true;
-            if (*it == "verbose3") msc_debug_verbose3 = true;
-            if (*it == "vin") msc_debug_vin = true;
-            if (*it == "script") msc_debug_script = true;
-            if (*it == "dex") msc_debug_dex = true;
-            if (*it == "send") msc_debug_send = true;
-            if (*it == "tokens") msc_debug_tokens = true;
-            if (*it == "spec") msc_debug_spec = true;
-            if (*it == "exo") msc_debug_exo = true;
-            if (*it == "tally") msc_debug_tally = true;
-            if (*it == "sp") msc_debug_sp = true;
-            if (*it == "sto") msc_debug_sto = true;
-            if (*it == "txdb") msc_debug_txdb = true;
-            if (*it == "tradedb") msc_debug_tradedb = true;
-            if (*it == "persistence") msc_debug_persistence = true;
-            if (*it == "ui") msc_debug_ui = true;
-            if (*it == "pending") msc_debug_pending = true;
-            if (*it == "metadex1") msc_debug_metadex1 = true;
-            if (*it == "metadex2") msc_debug_metadex2 = true;
-            if (*it == "metadex3") msc_debug_metadex3 = true;
-            if (*it == "none" || *it == "all") {
-                bool allDebugState = false;
-                if (*it == "all") allDebugState = true;
-                msc_debug_parser_data = allDebugState;
-                msc_debug_parser = allDebugState;
-                msc_debug_verbose = allDebugState;
-                msc_debug_verbose2 = allDebugState;
-                msc_debug_verbose3 = allDebugState;
-                msc_debug_vin = allDebugState;
-                msc_debug_script = allDebugState;
-                msc_debug_dex = allDebugState;
-                msc_debug_send = allDebugState;
-                msc_debug_tokens = allDebugState;
-                msc_debug_spec = allDebugState;
-                msc_debug_exo = allDebugState;
-                msc_debug_tally = allDebugState;
-                msc_debug_sp = allDebugState;
-                msc_debug_sto = allDebugState;
-                msc_debug_txdb = allDebugState;
-                msc_debug_tradedb = allDebugState;
-                msc_debug_persistence = allDebugState;
-                msc_debug_ui = allDebugState;
-                msc_debug_pending = allDebugState;
-                msc_debug_metadex1 = allDebugState;
-                msc_debug_metadex2 = allDebugState;
-                msc_debug_metadex3 = allDebugState;
-            }
-        }
-    }
 }
 
 /**
@@ -190,7 +149,7 @@ int LogFilePrint(const std::string& str)
         // Reopen the log file, if requested
         if (fReopenOmniCoreLog) {
             fReopenOmniCoreLog = false;
-            boost::filesystem::path pathDebug = GetDataDir() / LOG_FILENAME;
+            boost::filesystem::path pathDebug = GetLogPath();
             if (freopen(pathDebug.string().c_str(), "a", fileout) != NULL) {
                 setbuf(fileout, NULL); // Unbuffered
             }
@@ -255,58 +214,57 @@ void InitDebugLogLevels()
     }
 
     const std::vector<std::string>& debugLevels = mapMultiArgs["-omnidebug"];
-    if (!debugLevels.empty()) {
-        for (std::vector<std::string>::const_iterator it = debugLevels.begin(); it != debugLevels.end(); ++it) {
-            if (*it == "parser_data") msc_debug_parser_data = true;
-            if (*it == "parser") msc_debug_parser = true;
-            if (*it == "verbose") msc_debug_verbose = true;
-            if (*it == "verbose2") msc_debug_verbose2 = true;
-            if (*it == "verbose3") msc_debug_verbose3 = true;
-            if (*it == "vin") msc_debug_vin = true;
-            if (*it == "script") msc_debug_script = true;
-            if (*it == "dex") msc_debug_dex = true;
-            if (*it == "send") msc_debug_send = true;
-            if (*it == "tokens") msc_debug_tokens = true;
-            if (*it == "spec") msc_debug_spec = true;
-            if (*it == "exo") msc_debug_exo = true;
-            if (*it == "tally") msc_debug_tally = true;
-            if (*it == "sp") msc_debug_sp = true;
-            if (*it == "sto") msc_debug_sto = true;
-            if (*it == "txdb") msc_debug_txdb = true;
-            if (*it == "tradedb") msc_debug_tradedb = true;
-            if (*it == "persistence") msc_debug_persistence = true;
-            if (*it == "ui") msc_debug_ui = true;
-            if (*it == "pending") msc_debug_pending = true;
-            if (*it == "metadex1") msc_debug_metadex1 = true;
-            if (*it == "metadex2") msc_debug_metadex2 = true;
-            if (*it == "metadex3") msc_debug_metadex3 = true;
-            if (*it == "none" || *it == "all") {
-                bool allDebugState = false;
-                if (*it == "all") allDebugState = true;
-                msc_debug_parser_data = allDebugState;
-                msc_debug_parser = allDebugState;
-                msc_debug_verbose = allDebugState;
-                msc_debug_verbose2 = allDebugState;
-                msc_debug_verbose3 = allDebugState;
-                msc_debug_vin = allDebugState;
-                msc_debug_script = allDebugState;
-                msc_debug_dex = allDebugState;
-                msc_debug_send = allDebugState;
-                msc_debug_tokens = allDebugState;
-                msc_debug_spec = allDebugState;
-                msc_debug_exo = allDebugState;
-                msc_debug_tally = allDebugState;
-                msc_debug_sp = allDebugState;
-                msc_debug_sto = allDebugState;
-                msc_debug_txdb = allDebugState;
-                msc_debug_tradedb = allDebugState;
-                msc_debug_persistence = allDebugState;
-                msc_debug_ui = allDebugState;
-                msc_debug_pending = allDebugState;
-                msc_debug_metadex1 = allDebugState;
-                msc_debug_metadex2 = allDebugState;
-                msc_debug_metadex3 = allDebugState;
-            }
+
+    for (std::vector<std::string>::const_iterator it = debugLevels.begin(); it != debugLevels.end(); ++it) {
+        if (*it == "parser_data") msc_debug_parser_data = true;
+        if (*it == "parser") msc_debug_parser = true;
+        if (*it == "verbose") msc_debug_verbose = true;
+        if (*it == "verbose2") msc_debug_verbose2 = true;
+        if (*it == "verbose3") msc_debug_verbose3 = true;
+        if (*it == "vin") msc_debug_vin = true;
+        if (*it == "script") msc_debug_script = true;
+        if (*it == "dex") msc_debug_dex = true;
+        if (*it == "send") msc_debug_send = true;
+        if (*it == "tokens") msc_debug_tokens = true;
+        if (*it == "spec") msc_debug_spec = true;
+        if (*it == "exo") msc_debug_exo = true;
+        if (*it == "tally") msc_debug_tally = true;
+        if (*it == "sp") msc_debug_sp = true;
+        if (*it == "sto") msc_debug_sto = true;
+        if (*it == "txdb") msc_debug_txdb = true;
+        if (*it == "tradedb") msc_debug_tradedb = true;
+        if (*it == "persistence") msc_debug_persistence = true;
+        if (*it == "ui") msc_debug_ui = true;
+        if (*it == "pending") msc_debug_pending = true;
+        if (*it == "metadex1") msc_debug_metadex1 = true;
+        if (*it == "metadex2") msc_debug_metadex2 = true;
+        if (*it == "metadex3") msc_debug_metadex3 = true;
+        if (*it == "none" || *it == "all") {
+            bool allDebugState = false;
+            if (*it == "all") allDebugState = true;
+            msc_debug_parser_data = allDebugState;
+            msc_debug_parser = allDebugState;
+            msc_debug_verbose = allDebugState;
+            msc_debug_verbose2 = allDebugState;
+            msc_debug_verbose3 = allDebugState;
+            msc_debug_vin = allDebugState;
+            msc_debug_script = allDebugState;
+            msc_debug_dex = allDebugState;
+            msc_debug_send = allDebugState;
+            msc_debug_tokens = allDebugState;
+            msc_debug_spec = allDebugState;
+            msc_debug_exo = allDebugState;
+            msc_debug_tally = allDebugState;
+            msc_debug_sp = allDebugState;
+            msc_debug_sto = allDebugState;
+            msc_debug_txdb = allDebugState;
+            msc_debug_tradedb = allDebugState;
+            msc_debug_persistence = allDebugState;
+            msc_debug_ui = allDebugState;
+            msc_debug_pending = allDebugState;
+            msc_debug_metadex1 = allDebugState;
+            msc_debug_metadex2 = allDebugState;
+            msc_debug_metadex3 = allDebugState;
         }
     }
 }
@@ -316,7 +274,7 @@ void InitDebugLogLevels()
  */
 void ShrinkDebugLog()
 {
-    boost::filesystem::path pathLog = GetDataDir() / LOG_FILENAME;
+    boost::filesystem::path pathLog = GetLogPath();
     FILE* file = fopen(pathLog.string().c_str(), "r");
 
     if (file && boost::filesystem::file_size(pathLog) > LOG_SHRINKSIZE) {

--- a/src/omnicore/log.h
+++ b/src/omnicore/log.h
@@ -12,6 +12,9 @@ int LogFilePrint(const std::string& str);
 /** Prints to the console. */
 int ConsolePrint(const std::string& str);
 
+/** Determine whether to override compiled debug levels. */
+void InitDebugLogLevels();
+
 /** Scrolls log file, if it's getting too big. */
 void ShrinkDebugLog();
 

--- a/src/omnicore/log.h
+++ b/src/omnicore/log.h
@@ -51,20 +51,13 @@ extern bool msc_debug_metadex3;
  * of this macro-based construction (see tinyformat.h).
  */
 #define MAKE_OMNI_CORE_ERROR_AND_LOG_FUNC(n)                                    \
-    /** Log, if -debug=category switch is given OR category is NULL. */         \
     template<TINYFORMAT_ARGTYPES(n)>                                            \
-    static inline int mp_category_log(const char* category, const char* format, TINYFORMAT_VARARGS(n)) \
-    {                                                                           \
-        if (!LogAcceptCategory(category)) return 0;                             \
-        return LogFilePrint(tfm::format(format, TINYFORMAT_PASSARGS(n)));       \
-    }                                                                           \
-    template<TINYFORMAT_ARGTYPES(n)>                                            \
-    static inline int file_log(const char* format, TINYFORMAT_VARARGS(n))       \
+    static inline int PrintToLog(const char* format, TINYFORMAT_VARARGS(n))     \
     {                                                                           \
         return LogFilePrint(tfm::format(format, TINYFORMAT_PASSARGS(n)));       \
     }                                                                           \
     template<TINYFORMAT_ARGTYPES(n)>                                            \
-    static inline int file_log(TINYFORMAT_VARARGS(n))                           \
+    static inline int PrintToLog(TINYFORMAT_VARARGS(n))                         \
     {                                                                           \
         return LogFilePrint(tfm::format("%s", TINYFORMAT_PASSARGS(n)));         \
     }                                                                           \

--- a/src/omnicore/log.h
+++ b/src/omnicore/log.h
@@ -19,7 +19,6 @@ void InitDebugLogLevels();
 void ShrinkDebugLog();
 
 // Log files
-extern const std::string LOG_FILENAME;
 extern const std::string INFO_FILENAME;
 extern const std::string OWNERS_FILENAME;
 

--- a/src/omnicore/mdex.cpp
+++ b/src/omnicore/mdex.cpp
@@ -79,14 +79,14 @@ static MatchReturnType x_Trade(CMPMetaDEx* const pnew)
     MatchReturnType NewReturn = NOTHING;
     bool bBuyerSatisfied = false;
 
-    if (msc_debug_metadex1) file_log("%s(%s: prop=%d, desprop=%d, desprice= %s);newo: %s\n",
+    if (msc_debug_metadex1) PrintToLog("%s(%s: prop=%d, desprop=%d, desprice= %s);newo: %s\n",
         __FUNCTION__, pnew->getAddr(), propertyForSale, propertyDesired, xToString(pnew->inversePrice()), pnew->ToString());
 
     md_PricesMap* const ppriceMap = get_Prices(propertyDesired);
 
     // nothing for the desired property exists in the market, sorry!
     if (!ppriceMap) {
-        file_log("%s()=%d:%s NOT FOUND ON THE MARKET\n", __FUNCTION__, NewReturn, getTradeReturnType(NewReturn));
+        PrintToLog("%s()=%d:%s NOT FOUND ON THE MARKET\n", __FUNCTION__, NewReturn, getTradeReturnType(NewReturn));
         return NewReturn;
     }
 
@@ -94,7 +94,7 @@ static MatchReturnType x_Trade(CMPMetaDEx* const pnew)
     for (md_PricesMap::iterator priceIt = ppriceMap->begin(); priceIt != ppriceMap->end(); ++priceIt) { // check all prices
         const rational_t sellersPrice = priceIt->first;
 
-        if (msc_debug_metadex2) file_log("comparing prices: desprice %s needs to be GREATER THAN OR EQUAL TO %s\n",
+        if (msc_debug_metadex2) PrintToLog("comparing prices: desprice %s needs to be GREATER THAN OR EQUAL TO %s\n",
             xToString(pnew->inversePrice()), xToString(sellersPrice));
 
         // Is the desired price check satisfied? The buyer's inverse price must be larger than that of the seller.
@@ -110,7 +110,7 @@ static MatchReturnType x_Trade(CMPMetaDEx* const pnew)
             const CMPMetaDEx* const pold = &(*offerIt);
             assert(pold->unitPrice() == sellersPrice);
 
-            if (msc_debug_metadex1) file_log("Looking at existing: %s (its prop= %d, its des prop= %d) = %s\n",
+            if (msc_debug_metadex1) PrintToLog("Looking at existing: %s (its prop= %d, its des prop= %d) = %s\n",
                 xToString(sellersPrice), pold->getProperty(), pold->getDesProperty(), pold->ToString());
 
             // does the desired property match?
@@ -119,16 +119,16 @@ static MatchReturnType x_Trade(CMPMetaDEx* const pnew)
                 continue;
             }
 
-            if (msc_debug_metadex1) file_log("MATCH FOUND, Trade: %s = %s\n", xToString(sellersPrice), pold->ToString());
+            if (msc_debug_metadex1) PrintToLog("MATCH FOUND, Trade: %s = %s\n", xToString(sellersPrice), pold->ToString());
 
             // match found, execute trade now!
             const int64_t seller_amountForSale = pold->getAmountRemaining();
             const int64_t buyer_amountOffered = pnew->getAmountRemaining();
 
-            if (msc_debug_metadex1) file_log("$$ trading using price: %s; seller: forsale=%d, desired=%d, remaining=%d, buyer amount offered=%d\n",
+            if (msc_debug_metadex1) PrintToLog("$$ trading using price: %s; seller: forsale=%d, desired=%d, remaining=%d, buyer amount offered=%d\n",
                 xToString(sellersPrice), pold->getAmountForSale(), pold->getAmountDesired(), pold->getAmountRemaining(), pnew->getAmountRemaining());
-            if (msc_debug_metadex1) file_log("$$ old: %s\n", pold->ToString());
-            if (msc_debug_metadex1) file_log("$$ new: %s\n", pnew->ToString());
+            if (msc_debug_metadex1) PrintToLog("$$ old: %s\n", pold->ToString());
+            if (msc_debug_metadex1) PrintToLog("$$ new: %s\n", pnew->ToString());
 
             ///////////////////////////
 
@@ -159,7 +159,7 @@ static MatchReturnType x_Trade(CMPMetaDEx* const pnew)
             }
 
             if (nCouldBuy == 0) {
-                if (msc_debug_metadex1) file_log(
+                if (msc_debug_metadex1) PrintToLog(
                         "-- buyer has not enough tokens for sale to purchase one unit!\n");
                 ++offerIt;
                 continue;
@@ -178,7 +178,7 @@ static MatchReturnType x_Trade(CMPMetaDEx* const pnew)
             const rational_t xEffectivePrice(nWouldPay, nCouldBuy);
 
             if (xEffectivePrice > pnew->inversePrice()) {
-                if (msc_debug_metadex1) file_log(
+                if (msc_debug_metadex1) PrintToLog(
                         "-- effective price is too expensive: %s\n", xToString(xEffectivePrice));
                 ++offerIt;
                 continue;
@@ -189,7 +189,7 @@ static MatchReturnType x_Trade(CMPMetaDEx* const pnew)
             const int64_t buyer_amountLeft = pnew->getAmountRemaining() - seller_amountGot;
             const int64_t seller_amountLeft = pold->getAmountRemaining() - buyer_amountGot;
 
-            if (msc_debug_metadex1) file_log("$$ buyer_got= %d, seller_got= %d, seller_left_for_sale= %d, buyer_still_for_sale= %d\n",
+            if (msc_debug_metadex1) PrintToLog("$$ buyer_got= %d, seller_got= %d, seller_left_for_sale= %d, buyer_still_for_sale= %d\n",
                 buyer_amountGot, seller_amountGot, seller_amountLeft, buyer_amountLeft);
 
             ///////////////////////////
@@ -231,19 +231,19 @@ static MatchReturnType x_Trade(CMPMetaDEx* const pnew)
                 NewReturn = TRADED_MOREINSELLER;
             }
 
-            if (msc_debug_metadex1) file_log("==== TRADED !!! %u=%s\n", NewReturn, getTradeReturnType(NewReturn));
+            if (msc_debug_metadex1) PrintToLog("==== TRADED !!! %u=%s\n", NewReturn, getTradeReturnType(NewReturn));
 
             // record the trade in MPTradeList
             t_tradelistdb->recordTrade(pold->getHash(), pnew->getHash(), // < might just pass pold, pnew
                 pold->getAddr(), pnew->getAddr(), pold->getDesProperty(), pnew->getDesProperty(), seller_amountGot, buyer_amountGot, pnew->getBlock());
 
-            if (msc_debug_metadex1) file_log("++ erased old: %s\n", offerIt->ToString());
+            if (msc_debug_metadex1) PrintToLog("++ erased old: %s\n", offerIt->ToString());
             // erase the old seller element
             pofferSet->erase(offerIt++);
 
             // insert the updated one in place of the old
             if (0 < seller_replacement.getAmountRemaining()) {
-                file_log("++ inserting seller_replacement: %s\n", seller_replacement.ToString());
+                PrintToLog("++ inserting seller_replacement: %s\n", seller_replacement.ToString());
                 pofferSet->insert(seller_replacement);
             }
 
@@ -256,7 +256,7 @@ static MatchReturnType x_Trade(CMPMetaDEx* const pnew)
         if (bBuyerSatisfied) break;
     } // check all prices
 
-    file_log("%s()=%d:%s\n", __FUNCTION__, NewReturn, getTradeReturnType(NewReturn));
+    PrintToLog("%s()=%d:%s\n", __FUNCTION__, NewReturn, getTradeReturnType(NewReturn));
 
     return NewReturn;
 }
@@ -307,7 +307,7 @@ uint64_t CMPMetaDEx::getBlockTime() const
 void CMPMetaDEx::setAmountRemaining(int64_t amount, const std::string& label)
 {
     amount_remaining = amount;
-    file_log("update remaining amount still up for sale (%ld %s):%s\n", amount, label, ToString());
+    PrintToLog("update remaining amount still up for sale (%ld %s):%s\n", amount, label, ToString());
 }
 
 void CMPMetaDEx::Set(const std::string& sa, int b, uint32_t c, int64_t nValue, uint32_t cd, int64_t ad, const uint256& tx, uint32_t i, uint8_t suba)
@@ -404,7 +404,7 @@ int mastercore::MetaDEx_ADD(const std::string& sender_addr, uint32_t prop, int64
 
     // Create a MetaDEx object from paremeters
     CMPMetaDEx new_mdex(sender_addr, block, prop, amount, property_desired, amount_desired, txid, idx, CMPTransaction::ADD);
-    if (msc_debug_metadex1) file_log("%s(); buyer obj: %s\n", __FUNCTION__, new_mdex.ToString());
+    if (msc_debug_metadex1) PrintToLog("%s(); buyer obj: %s\n", __FUNCTION__, new_mdex.ToString());
 
     // Ensure this is not a badly priced trade (for example due to zero amounts)
     if (0 >= new_mdex.unitPrice()) return METADEX_ERROR -66;
@@ -417,14 +417,14 @@ int mastercore::MetaDEx_ADD(const std::string& sender_addr, uint32_t prop, int64
     // Insert the remaining order into the MetaDEx maps
     if (0 < new_mdex.getAmountRemaining()) { //switch to getAmountRemaining() when ready
         if (!MetaDEx_INSERT(new_mdex)) {
-            file_log("%s() ERROR: ALREADY EXISTS, line %d, file: %s\n", __FUNCTION__, __LINE__, __FILE__);
+            PrintToLog("%s() ERROR: ALREADY EXISTS, line %d, file: %s\n", __FUNCTION__, __LINE__, __FILE__);
             return METADEX_ERROR -70;
         } else {
             // move tokens into reserve
             assert(update_tally_map(sender_addr, prop, -new_mdex.getAmountRemaining(), BALANCE));
             assert(update_tally_map(sender_addr, prop, new_mdex.getAmountRemaining(), METADEX_RESERVE));
 
-            if (msc_debug_metadex1) file_log("==== INSERTED: %s= %s\n", xToString(new_mdex.unitPrice()), new_mdex.ToString());
+            if (msc_debug_metadex1) PrintToLog("==== INSERTED: %s= %s\n", xToString(new_mdex.unitPrice()), new_mdex.ToString());
             if (msc_debug_metadex3) MetaDEx_debug_print();
         }
     }
@@ -440,12 +440,12 @@ int mastercore::MetaDEx_CANCEL_AT_PRICE(const uint256& txid, unsigned int block,
     md_PricesMap* prices = get_Prices(prop);
     const CMPMetaDEx* p_mdex = NULL;
 
-    if (msc_debug_metadex1) file_log("%s():%s\n", __FUNCTION__, mdex.ToString());
+    if (msc_debug_metadex1) PrintToLog("%s():%s\n", __FUNCTION__, mdex.ToString());
 
     if (msc_debug_metadex2) MetaDEx_debug_print();
 
     if (!prices) {
-        file_log("%s() NOTHING FOUND for %s\n", __FUNCTION__, mdex.ToString());
+        PrintToLog("%s() NOTHING FOUND for %s\n", __FUNCTION__, mdex.ToString());
         return rc -1;
     }
 
@@ -460,7 +460,7 @@ int mastercore::MetaDEx_CANCEL_AT_PRICE(const uint256& txid, unsigned int block,
         for (md_Set::iterator iitt = indexes->begin(); iitt != indexes->end();) {
             p_mdex = &(*iitt);
 
-            if (msc_debug_metadex3) file_log("%s(): %s\n", __FUNCTION__, p_mdex->ToString());
+            if (msc_debug_metadex3) PrintToLog("%s(): %s\n", __FUNCTION__, p_mdex->ToString());
 
             if ((p_mdex->getDesProperty() != property_desired) || (p_mdex->getAddr() != sender_addr)) {
                 ++iitt;
@@ -468,7 +468,7 @@ int mastercore::MetaDEx_CANCEL_AT_PRICE(const uint256& txid, unsigned int block,
             }
 
             rc = 0;
-            file_log("%s(): REMOVING %s\n", __FUNCTION__, p_mdex->ToString());
+            PrintToLog("%s(): REMOVING %s\n", __FUNCTION__, p_mdex->ToString());
 
             // move from reserve to main
             assert(update_tally_map(p_mdex->getAddr(), p_mdex->getProperty(), -p_mdex->getAmountRemaining(), METADEX_RESERVE));
@@ -493,12 +493,12 @@ int mastercore::MetaDEx_CANCEL_ALL_FOR_PAIR(const uint256& txid, unsigned int bl
     md_PricesMap* prices = get_Prices(prop);
     const CMPMetaDEx* p_mdex = NULL;
 
-    file_log("%s(%d,%d)\n", __FUNCTION__, prop, property_desired);
+    PrintToLog("%s(%d,%d)\n", __FUNCTION__, prop, property_desired);
 
     if (msc_debug_metadex3) MetaDEx_debug_print();
 
     if (!prices) {
-        file_log("%s() NOTHING FOUND\n", __FUNCTION__);
+        PrintToLog("%s() NOTHING FOUND\n", __FUNCTION__);
         return rc -1;
     }
 
@@ -509,7 +509,7 @@ int mastercore::MetaDEx_CANCEL_ALL_FOR_PAIR(const uint256& txid, unsigned int bl
         for (md_Set::iterator iitt = indexes->begin(); iitt != indexes->end();) {
             p_mdex = &(*iitt);
 
-            if (msc_debug_metadex3) file_log("%s(): %s\n", __FUNCTION__, p_mdex->ToString());
+            if (msc_debug_metadex3) PrintToLog("%s(): %s\n", __FUNCTION__, p_mdex->ToString());
 
             if ((p_mdex->getDesProperty() != property_desired) || (p_mdex->getAddr() != sender_addr)) {
                 ++iitt;
@@ -517,7 +517,7 @@ int mastercore::MetaDEx_CANCEL_ALL_FOR_PAIR(const uint256& txid, unsigned int bl
             }
 
             rc = 0;
-            file_log("%s(): REMOVING %s\n", __FUNCTION__, p_mdex->ToString());
+            PrintToLog("%s(): REMOVING %s\n", __FUNCTION__, p_mdex->ToString());
 
             // move from reserve to main
             assert(update_tally_map(p_mdex->getAddr(), p_mdex->getProperty(), -p_mdex->getAmountRemaining(), METADEX_RESERVE));
@@ -543,11 +543,11 @@ int mastercore::MetaDEx_CANCEL_EVERYTHING(const uint256& txid, unsigned int bloc
 {
     int rc = METADEX_ERROR -40;
 
-    file_log("%s()\n", __FUNCTION__);
+    PrintToLog("%s()\n", __FUNCTION__);
 
     if (msc_debug_metadex2) MetaDEx_debug_print();
 
-    file_log("<<<<<<\n");
+    PrintToLog("<<<<<<\n");
 
     for (md_PropertiesMap::iterator my_it = metadex.begin(); my_it != metadex.end(); ++my_it) {
         unsigned int prop = my_it->first;
@@ -556,17 +556,17 @@ int mastercore::MetaDEx_CANCEL_EVERYTHING(const uint256& txid, unsigned int bloc
         if (isMainEcosystemProperty(ecosystem) && !isMainEcosystemProperty(prop)) continue;
         if (isTestEcosystemProperty(ecosystem) && !isTestEcosystemProperty(prop)) continue;
 
-        file_log(" ## property: %u\n", prop);
+        PrintToLog(" ## property: %u\n", prop);
         md_PricesMap& prices = my_it->second;
 
         for (md_PricesMap::iterator it = prices.begin(); it != prices.end(); ++it) {
             rational_t price = it->first;
             md_Set& indexes = it->second;
 
-            file_log("  # Price Level: %s\n", xToString(price));
+            PrintToLog("  # Price Level: %s\n", xToString(price));
 
             for (md_Set::iterator it = indexes.begin(); it != indexes.end();) {
-                file_log("%s= %s\n", xToString(price), it->ToString());
+                PrintToLog("%s= %s\n", xToString(price), it->ToString());
 
                 if (it->getAddr() != sender_addr) {
                     ++it;
@@ -574,7 +574,7 @@ int mastercore::MetaDEx_CANCEL_EVERYTHING(const uint256& txid, unsigned int bloc
                 }
 
                 rc = 0;
-                file_log("%s(): REMOVING %s\n", __FUNCTION__, it->ToString());
+                PrintToLog("%s(): REMOVING %s\n", __FUNCTION__, it->ToString());
 
                 // move from reserve to balance
                 assert(update_tally_map(it->getAddr(), it->getProperty(), -it->getAmountRemaining(), METADEX_RESERVE));
@@ -588,7 +588,7 @@ int mastercore::MetaDEx_CANCEL_EVERYTHING(const uint256& txid, unsigned int bloc
             }
         }
     }
-    file_log(">>>>>>\n");
+    PrintToLog(">>>>>>\n");
 
     if (msc_debug_metadex2) MetaDEx_debug_print();
 
@@ -615,26 +615,26 @@ bool mastercore::MetaDEx_isOpen(const uint256& txid, uint32_t propertyIdForSale)
 
 void mastercore::MetaDEx_debug_print(bool bShowPriceLevel, bool bDisplay)
 {
-    file_log("<<<\n");
+    PrintToLog("<<<\n");
     for (md_PropertiesMap::iterator my_it = metadex.begin(); my_it != metadex.end(); ++my_it) {
         uint32_t prop = my_it->first;
 
-        file_log(" ## property: %u\n", prop);
+        PrintToLog(" ## property: %u\n", prop);
         md_PricesMap& prices = my_it->second;
 
         for (md_PricesMap::iterator it = prices.begin(); it != prices.end(); ++it) {
             rational_t price = it->first;
             md_Set& indexes = it->second;
 
-            if (bShowPriceLevel) file_log("  # Price Level: %s\n", xToString(price));
+            if (bShowPriceLevel) PrintToLog("  # Price Level: %s\n", xToString(price));
 
             for (md_Set::iterator it = indexes.begin(); it != indexes.end(); ++it) {
                 const CMPMetaDEx& obj = *it;
 
                 if (bDisplay) PrintToConsole("%s= %s\n", xToString(price), obj.ToString());
-                else file_log("%s= %s\n", xToString(price), obj.ToString());
+                else PrintToLog("%s= %s\n", xToString(price), obj.ToString());
             }
         }
     }
-    file_log(">>>\n");
+    PrintToLog(">>>\n");
 }

--- a/src/omnicore/omnicore.cpp
+++ b/src/omnicore/omnicore.cpp
@@ -447,12 +447,12 @@ bool mastercore::parseAlertMessage(std::string rawAlertStr, int32_t *alertType, 
             *typeCheck = boost::lexical_cast<uint32_t>(vstr[2]);
             *verCheck = boost::lexical_cast<uint32_t>(vstr[3]);
         } catch (const boost::bad_lexical_cast &e) {
-            file_log("DEBUG ALERT - error in converting values from global alert string\n");
+            PrintToLog("DEBUG ALERT - error in converting values from global alert string\n");
             return false; //(something went wrong)
         }
         *alertMessage = vstr[4];
         if ((*alertType < 1) || (*alertType > 4) || (*expiryValue == 0)) {
-            file_log("DEBUG ALERT ERROR - Something went wrong decoding the global alert string, values are not as expected.\n");
+            PrintToLog("DEBUG ALERT ERROR - Something went wrong decoding the global alert string, values are not as expected.\n");
             return false;
         }
         return true;
@@ -473,7 +473,7 @@ std::string mastercore::getMasterCoreAlertTextOnly()
         }
         else
         {
-            file_log("DEBUG ALERT ERROR - Something went wrong decoding the global alert string, there are not 5 tokens\n");
+            PrintToLog("DEBUG ALERT ERROR - Something went wrong decoding the global alert string, there are not 5 tokens\n");
             return "";
         }
     }
@@ -499,7 +499,7 @@ bool mastercore::checkExpiredAlerts(unsigned int curBlock, uint64_t curTime)
                      if (curBlock > expiryValue)
                      {
                          //the alert has expired, clear the global alert string
-                         file_log("DEBUG ALERT - Expiring alert string %s\n",global_alert_message.c_str());
+                         PrintToLog("DEBUG ALERT - Expiring alert string %s\n", global_alert_message);
                          global_alert_message = "";
                          return true;
                      }
@@ -508,7 +508,7 @@ bool mastercore::checkExpiredAlerts(unsigned int curBlock, uint64_t curTime)
                      if (curTime > expiryValue)
                      {
                          //the alert has expired, clear the global alert string
-                         file_log("DEBUG ALERT - Expiring alert string %s\n",global_alert_message.c_str());
+                         PrintToLog("DEBUG ALERT - Expiring alert string %s\n", global_alert_message);
                          global_alert_message = "";
                          return true;
                      }
@@ -517,7 +517,7 @@ bool mastercore::checkExpiredAlerts(unsigned int curBlock, uint64_t curTime)
                      if (OMNICORE_VERSION > expiryValue)
                      {
                          //the alert has expired, clear the global alert string
-                         file_log("DEBUG ALERT - Expiring alert string %s\n",global_alert_message.c_str());
+                         PrintToLog("DEBUG ALERT - Expiring alert string %s\n", global_alert_message);
                          global_alert_message = "";
                          return true;
                      }
@@ -537,7 +537,7 @@ bool mastercore::checkExpiredAlerts(unsigned int curBlock, uint64_t curTime)
                      {
                          // we know we have transactions live we don't understand
                          // can't be trusted to provide valid data, shutdown
-                         file_log("DEBUG ALERT - Shutting down due to unsupported live TX - alert string %s\n", global_alert_message);
+                         PrintToLog("DEBUG ALERT - Shutting down due to unsupported live TX - alert string %s\n", global_alert_message);
                          PrintToConsole("DEBUG ALERT - Shutting down due to unsupported live TX - alert string %s\n", global_alert_message); // echo to screen
                          if (!GetBoolArg("-overrideforcedshutdown", false)) {
                              std::string msgText = "Shutting down due to alert: " + getMasterCoreAlertTextOnly();
@@ -555,7 +555,7 @@ bool mastercore::checkExpiredAlerts(unsigned int curBlock, uint64_t curTime)
                      if (txSupported)
                      {
                          // we can simply expire this update as this version supports the new coming TX
-                         file_log("DEBUG ALERT - Expiring alert string %s\n",global_alert_message.c_str());
+                         PrintToLog("DEBUG ALERT - Expiring alert string %s\n",global_alert_message);
                          global_alert_message = "";
                          return true;
                      }
@@ -587,7 +587,7 @@ int64_t prev = 0, owners = 0;
   {
       for(map<string, CMPTally>::iterator my_it = mp_tally_map.begin(); my_it != mp_tally_map.end(); ++my_it)
       {
-          string address = (my_it->first).c_str();
+          string address = my_it->first;
           totalTokens += getMPbalance(address, propertyId, BALANCE);
           totalTokens += getMPbalance(address, propertyId, SELLOFFER_RESERVE);
           totalTokens += getMPbalance(address, propertyId, METADEX_RESERVE);
@@ -619,7 +619,7 @@ int64_t before, after;
 
   if (0 == amount)
   {
-    file_log("%s(%s, %u=0x%X, %+ld, ttype= %d) 0 FUNDS !\n", __FUNCTION__, who.c_str(), which_property, which_property, amount, ttype);
+    PrintToLog("%s(%s, %u=0x%X, %+ld, ttype= %d) 0 FUNDS !\n", __FUNCTION__, who, which_property, which_property, amount, ttype);
     return false;
   }
 
@@ -639,14 +639,14 @@ int64_t before, after;
   bRet = tally.updateMoney(which_property, amount, ttype);
 
   after = getMPbalance(who, which_property, ttype);
-  if (!bRet) file_log("%s(%s, %u=0x%X, %+ld, ttype=%d) INSUFFICIENT FUNDS\n", __FUNCTION__, who.c_str(), which_property, which_property, amount, ttype);
+  if (!bRet) PrintToLog("%s(%s, %u=0x%X, %+ld, ttype=%d) INSUFFICIENT FUNDS\n", __FUNCTION__, who, which_property, which_property, amount, ttype);
 
   if (msc_debug_tally)
   {
     if ((exodus_address != who) || (exodus_address == who && msc_debug_exo))
     {
-      file_log("%s(%s, %u=0x%X, %+ld, ttype=%d); before=%ld, after=%ld\n",
-       __FUNCTION__, who.c_str(), which_property, which_property, amount, ttype, before, after);
+      PrintToLog("%s(%s, %u=0x%X, %+ld, ttype=%d); before=%ld, after=%ld\n",
+       __FUNCTION__, who, which_property, which_property, amount, ttype, before, after);
     }
   }
 
@@ -743,7 +743,7 @@ unsigned short version_TopAllowed;
 
     if (version_TopAllowed < version)
     {
-      file_log("Black Hole identified !!! %d, %u, %u, %u\n", txBlock, txProperty, txType, version);
+      PrintToLog("Black Hole identified !!! %d, %u, %u, %u\n", txBlock, txProperty, txType, version);
 
       bBlackHole = true;
 
@@ -786,7 +786,7 @@ const double available_reward=all_reward * part_available;
   devmsc = rounduint64(available_reward);
   exodus_delta = devmsc - exodus_prev;
 
-  if (msc_debug_exo) file_log("devmsc=%lu, exodus_prev=%lu, exodus_delta=%ld\n", devmsc, exodus_prev, exodus_delta);
+  if (msc_debug_exo) PrintToLog("devmsc=%lu, exodus_prev=%lu, exodus_delta=%ld\n", devmsc, exodus_prev, exodus_delta);
 
   // skip if a block's timestamp is older than that of a previous one!
   if (0>exodus_delta) return 0;
@@ -872,7 +872,7 @@ int TXExodusFundraiser(const CTransaction &wtx, const string &sender, int64_t Ex
     }
 
     uint64_t msc_tot= round( 100 * ExodusHighestValue * bonus ); 
-    if (msc_debug_exo) file_log("Exodus Fundraiser tx detected, tx %s generated %lu.%08lu\n",wtx.GetHash().ToString().c_str(), msc_tot / COIN, msc_tot % COIN);
+    if (msc_debug_exo) PrintToLog("Exodus Fundraiser tx detected, tx %s generated %lu.%08lu\n",wtx.GetHash().ToString(), msc_tot / COIN, msc_tot % COIN);
  
     update_tally_map(sender, OMNI_PROPERTY_MSC, msc_tot, BALANCE);
     update_tally_map(sender, OMNI_PROPERTY_TMSC, msc_tot, BALANCE);
@@ -966,8 +966,8 @@ int parseTransaction(bool bRPConly, const CTransaction &wtx, int nBlock, unsigne
       }
   }
   if ((isNonMainNet() && getmoney_count)) {} else if ((!marker_count) && (!hasOmniBytes)) { return -1; } // no Exodus/omni marker, not a valid Omni transaction
-  file_log("____________________________________________________________________________________________________________________________________\n");
-  file_log("%s(block=%d, %s idx= %d); txid: %s\n", __FUNCTION__, nBlock, DateTimeStrFormat("%Y-%m-%d %H:%M:%S", nTime).c_str(), idx, wtx.GetHash().GetHex().c_str());
+  PrintToLog("____________________________________________________________________________________________________________________________________\n");
+  PrintToLog("%s(block=%d, %s idx= %d); txid: %s\n", __FUNCTION__, nBlock, DateTimeStrFormat("%Y-%m-%d %H:%M:%S", nTime), idx, wtx.GetHash().GetHex());
 
 
   // ### DATA POPULATION ### - save output addresses, scripts, multsig and op_return data and determine tx class
@@ -981,7 +981,7 @@ int parseTransaction(bool bRPConly, const CTransaction &wtx, int nBlock, unsigne
       if (ExtractDestination(wtx.vout[i].scriptPubKey, dest)) {
           strAddress = CBitcoinAddress(dest).ToString();
           if ((exodus_address != strAddress) && (validType)) {
-              if (msc_debug_parser_data) file_log("saving address_data #%d: %s:%s\n", i, strAddress.c_str(), wtx.vout[i].scriptPubKey.ToString().c_str());
+              if (msc_debug_parser_data) PrintToLog("saving address_data #%d: %s:%s\n", i, strAddress, wtx.vout[i].scriptPubKey.ToString());
               // saving for Class A processing or reference
               GetScriptPushes(wtx.vout[i].scriptPubKey, script_data);
               address_data.push_back(strAddress);
@@ -993,7 +993,7 @@ int parseTransaction(bool bRPConly, const CTransaction &wtx, int nBlock, unsigne
               GetScriptPushes(wtx.vout[i].scriptPubKey, op_return_script_data); // only one OP_RETURN output permitted per tx
               string debug_op_string;
               if (op_return_script_data.size() > 0) debug_op_string=op_return_script_data[0];
-              if (msc_debug_parser_data) file_log("Class C transaction detected: %s parsed to %s at vout %d\n", wtx.GetHash().GetHex().c_str(), debug_op_string.c_str(), i);
+              if (msc_debug_parser_data) PrintToLog("Class C transaction detected: %s parsed to %s at vout %d\n", wtx.GetHash().GetHex(), debug_op_string, i);
           } else { // likeky a multisig
               txnouttype type;
               std::vector<CTxDestination> vDest;
@@ -1002,7 +1002,7 @@ int parseTransaction(bool bRPConly, const CTransaction &wtx, int nBlock, unsigne
           }
       }
   }
-  if (msc_debug_parser_data) file_log(" address_data.size=%lu\n script_data.size=%lu\n value_data.size=%lu\n", address_data.size(), script_data.size(), value_data.size());
+  if (msc_debug_parser_data) PrintToLog(" address_data.size=%lu\n script_data.size=%lu\n value_data.size=%lu\n", address_data.size(), script_data.size(), value_data.size());
 
 
   // ### CLASS IDENTIFICATION ###
@@ -1015,7 +1015,7 @@ int parseTransaction(bool bRPConly, const CTransaction &wtx, int nBlock, unsigne
   int inputs_errors = 0;  // several types of erroroneous MP TX inputs
   map <string, uint64_t> inputs_sum_of_values;
   for (unsigned int i = 0; i < wtx.vin.size(); i++) {
-      if (msc_debug_vin) file_log("vin=%d:%s\n", i, wtx.vin[i].scriptSig.ToString().c_str());
+      if (msc_debug_vin) PrintToLog("vin=%d:%s\n", i, wtx.vin[i].scriptSig.ToString());
       CTransaction txPrev;
       uint256 hashBlock;
       if (!GetTransaction(wtx.vin[i].prevout.hash, txPrev, hashBlock, true)) { return -101; } // get the vin's previous transaction
@@ -1030,7 +1030,7 @@ int parseTransaction(bool bRPConly, const CTransaction &wtx, int nBlock, unsigne
           inputs_sum_of_values[addressSource.ToString()] += txPrev.vout[n].nValue;
       }
       else ++inputs_errors;
-      if (msc_debug_vin) file_log("vin=%d:%s\n", i, wtx.vin[i].ToString().c_str());
+      if (msc_debug_vin) PrintToLog("vin=%d:%s\n", i, wtx.vin[i].ToString());
   }
   if (inputs_errors) { return -101; } // not a valid Omni TX, disallowed inputs invalidate the transaction
   txFee = inAll - outAll; // miner fee
@@ -1039,14 +1039,14 @@ int parseTransaction(bool bRPConly, const CTransaction &wtx, int nBlock, unsigne
       uint64_t nTemp = my_it->second;
       if (nTemp > nMax) {
           strSender = my_it->first;
-          if (msc_debug_exo) file_log("looking for The Sender: %s , nMax=%lu, nTemp=%lu\n", strSender.c_str(), nMax, nTemp);
+          if (msc_debug_exo) PrintToLog("looking for The Sender: %s , nMax=%lu, nTemp=%lu\n", strSender, nMax, nTemp);
           nMax = nTemp;
       }
   }
   if (!strSender.empty()) {
-      if (msc_debug_verbose) file_log("The Sender: %s : His Input Sum of Values= %lu.%08lu ; fee= %lu.%08lu\n", strSender.c_str(), nMax / COIN, nMax % COIN, txFee/COIN, txFee%COIN);
+      if (msc_debug_verbose) PrintToLog("The Sender: %s : His Input Sum of Values= %lu.%08lu ; fee= %lu.%08lu\n", strSender, nMax / COIN, nMax % COIN, txFee/COIN, txFee%COIN);
   } else {
-      file_log("The sender is still EMPTY !!! txid: %s\n", wtx.GetHash().GetHex().c_str());
+      PrintToLog("The sender is still EMPTY !!! txid: %s\n", wtx.GetHash().GetHex());
       return -5;
   }
 
@@ -1065,16 +1065,16 @@ int parseTransaction(bool bRPConly, const CTransaction &wtx, int nBlock, unsigne
           txnouttype type;
           std::vector<CTxDestination> vDest;
           int nRequired;
-          if (msc_debug_script) file_log("scriptPubKey: %s\n", HexStr(wtx.vout[i].scriptPubKey));
+          if (msc_debug_script) PrintToLog("scriptPubKey: %s\n", HexStr(wtx.vout[i].scriptPubKey));
           if (ExtractDestinations(wtx.vout[i].scriptPubKey, type, vDest, nRequired)) {
-              if (msc_debug_script) file_log(" >> multisig: ");
+              if (msc_debug_script) PrintToLog(" >> multisig: ");
               BOOST_FOREACH(const CTxDestination &dest, vDest) {
                   CBitcoinAddress address = CBitcoinAddress(dest);
                   CKeyID keyID;
                   if (!address.GetKeyID(keyID)) { } // TODO: add an error handler
-                  if (msc_debug_script) file_log("%s ; ", address.ToString().c_str());
+                  if (msc_debug_script) PrintToLog("%s ; ", address.ToString());
               }
-              if (msc_debug_script) file_log("\n");
+              if (msc_debug_script) PrintToLog("\n");
               // ignore first public key, as it should belong to the sender
               // and it be used to avoid the creation of unspendable dust
               GetScriptPushes(wtx.vout[i].scriptPubKey, multisig_script_data, true);
@@ -1110,10 +1110,10 @@ int parseTransaction(bool bRPConly, const CTransaction &wtx, int nBlock, unsigne
                   strDataAddress = address_data[k]; // record data address
                   dataAddressSeq = seq; // record data address seq num for reference matching
                   dataAddressValue = value_data[k]; // record data address amount for reference matching
-                  if (msc_debug_parser_data) file_log("Data Address located - data[%d]:%s: %s (%lu.%08lu)\n", k, script_data[k].c_str(), address_data[k].c_str(), value_data[k] / COIN, value_data[k] % COIN);
+                  if (msc_debug_parser_data) PrintToLog("Data Address located - data[%d]:%s: %s (%lu.%08lu)\n", k, script_data[k], address_data[k], value_data[k] / COIN, value_data[k] % COIN);
               } else { // invalidate - Class A cannot be more than one data packet - possible collision, treat as default (BTC payment)
                   strDataAddress = ""; //empty strScriptData to block further parsing
-                  if (msc_debug_parser_data) file_log("Multiple Data Addresses found (collision?) Class A invalidated, defaulting to BTC payment\n");
+                  if (msc_debug_parser_data) PrintToLog("Multiple Data Addresses found (collision?) Class A invalidated, defaulting to BTC payment\n");
                   break;
               }
           }
@@ -1128,10 +1128,10 @@ int parseTransaction(bool bRPConly, const CTransaction &wtx, int nBlock, unsigne
               if ((address_data[k] != strDataAddress) && (address_data[k] != exodus_address) && (expectedRefAddressSeq == seq)) { // found reference address with matching sequence number
                   if (strRefAddress.empty()) { // confirm we have not already located a reference address
                       strRefAddress = address_data[k]; // set ref address
-                      if (msc_debug_parser_data) file_log("Reference Address located via seqnum - data[%d]:%s: %s (%lu.%08lu)\n", k, script_data[k].c_str(), address_data[k].c_str(), value_data[k] / COIN, value_data[k] % COIN);
+                      if (msc_debug_parser_data) PrintToLog("Reference Address located via seqnum - data[%d]:%s: %s (%lu.%08lu)\n", k, script_data[k], address_data[k], value_data[k] / COIN, value_data[k] % COIN);
                   } else { // can't trust sequence numbers to provide reference address, there is a collision with >1 address with expected seqnum
                       strRefAddress = ""; // blank ref address
-                      if (msc_debug_parser_data) file_log("Reference Address sequence number collision, will fall back to evaluating matching output amounts\n");
+                      if (msc_debug_parser_data) PrintToLog("Reference Address sequence number collision, will fall back to evaluating matching output amounts\n");
                       break;
                   }
               }
@@ -1146,10 +1146,10 @@ int parseTransaction(bool bRPConly, const CTransaction &wtx, int nBlock, unsigne
                           if (value_data[k] == ExodusValues[exodus_idx]) { //this output matches data address value and exodus address value, choose as ref
                               if (strRefAddress.empty()) {
                                   strRefAddress = address_data[k];
-                                  if (msc_debug_parser_data) file_log("Reference Address located via matching amounts - data[%d]:%s: %s (%lu.%08lu)\n", k, script_data[k].c_str(), address_data[k].c_str(), value_data[k] / COIN, value_data[k] % COIN);
+                                  if (msc_debug_parser_data) PrintToLog("Reference Address located via matching amounts - data[%d]:%s: %s (%lu.%08lu)\n", k, script_data[k], address_data[k], value_data[k] / COIN, value_data[k] % COIN);
                               } else {
                                   strRefAddress = "";
-                                  if (msc_debug_parser_data) file_log("Reference Address collision, multiple potential candidates. Class A invalidated, defaulting to BTC payment\n");
+                                  if (msc_debug_parser_data) PrintToLog("Reference Address collision, multiple potential candidates. Class A invalidated, defaulting to BTC payment\n");
                                   break;
                               }
                           }
@@ -1161,13 +1161,13 @@ int parseTransaction(bool bRPConly, const CTransaction &wtx, int nBlock, unsigne
       if (!strRefAddress.empty()) strReference=strRefAddress; // populate expected var strReference with chosen address (if not empty)
       if (strRefAddress.empty()) strDataAddress=""; // last validation step, if strRefAddress is empty, blank strDataAddress so we default to BTC payment
       if (!strDataAddress.empty()) { // valid Class A packet almost ready
-          if (msc_debug_parser_data) file_log("valid Class A:from=%s:to=%s:data=%s\n", strSender.c_str(), strReference.c_str(), strScriptData.c_str());
+          if (msc_debug_parser_data) PrintToLog("valid Class A:from=%s:to=%s:data=%s\n", strSender, strReference, strScriptData);
           packet_size = PACKET_SIZE_CLASS_A;
           memcpy(single_pkt, &ParseHex(strScriptData)[0], packet_size);
       } else {
           // ### BTC PAYMENT FOR DEX HANDLING ###
-          file_log("!! sender: %s , receiver: %s\n", strSender.c_str(), strReference.c_str());
-          file_log("!! this may be the BTC payment for an offer !!\n");
+          PrintToLog("!! sender: %s , receiver: %s\n", strSender, strReference);
+          PrintToLog("!! this may be the BTC payment for an offer !!\n");
           // TODO collect all payments made to non-itself & non-exodus and their amounts -- these may be purchases!!!
           int count = 0;
           for (unsigned int i = 0; i < wtx.vout.size(); i++) {
@@ -1175,7 +1175,7 @@ int parseTransaction(bool bRPConly, const CTransaction &wtx, int nBlock, unsigne
               if (ExtractDestination(wtx.vout[i].scriptPubKey, dest)) {
                   const string strAddress = CBitcoinAddress(dest).ToString();
                   if (exodus_address == strAddress) continue;
-                  file_log("payment #%d %s %11.8lf\n", count, strAddress.c_str(), (double)wtx.vout[i].nValue/(double)COIN);
+                  PrintToLog("payment #%d %s %11.8lf\n", count, strAddress, (double)wtx.vout[i].nValue/(double)COIN);
                   // check everything & pay BTC for the property we are buying here...
                   if (bRPConly) count = 55555;  // no real way to validate a payment during simple RPC call
                   else if (0 == DEx_payment(wtx.GetHash(), i, strAddress, strSender, wtx.vout[i].nValue, nBlock)) ++count;
@@ -1189,52 +1189,52 @@ int parseTransaction(bool bRPConly, const CTransaction &wtx, int nBlock, unsigne
   // ### CLASS B / CLASS C PARSING ###
   if ((omniClass == OMNI_CLASS_B) || (omniClass == OMNI_CLASS_C)) {
       unsigned int k = 0;
-      if (msc_debug_parser_data) file_log("Beginning reference identification\n");
+      if (msc_debug_parser_data) PrintToLog("Beginning reference identification\n");
       bool referenceFound = false; // bool to hold whether we've found the reference yet
       bool changeRemoved = false; // bool to hold whether we've ignored the first output to sender as change
       unsigned int potentialReferenceOutputs = 0; // int to hold number of potential reference outputs
       BOOST_FOREACH(const string &addr, address_data) { // how many potential reference outputs do we have, if just one select it right here
-          if (msc_debug_parser_data) file_log("ref? data[%d]:%s: %s (%lu.%08lu)\n", k, script_data[k].c_str(), addr.c_str(), value_data[k] / COIN, value_data[k] % COIN);
+          if (msc_debug_parser_data) PrintToLog("ref? data[%d]:%s: %s (%lu.%08lu)\n", k, script_data[k], addr, value_data[k] / COIN, value_data[k] % COIN);
           ++k;
           if (addr != exodus_address) {
               ++potentialReferenceOutputs;
               if (1 == potentialReferenceOutputs) {
                   strReference = addr;
                   referenceFound = true;
-                  if (msc_debug_parser_data) file_log("Single reference potentially id'd as follows: %s \n", strReference.c_str());
+                  if (msc_debug_parser_data) PrintToLog("Single reference potentially id'd as follows: %s \n", strReference);
               } else { //as soon as potentialReferenceOutputs > 1 we need to go fishing
                   strReference = ""; // avoid leaving strReference populated for sanity
                   referenceFound = false;
-                  if (msc_debug_parser_data) file_log("More than one potential reference candidate, blanking strReference, need to go fishing\n");
+                  if (msc_debug_parser_data) PrintToLog("More than one potential reference candidate, blanking strReference, need to go fishing\n");
               }
           }
       }
       if (!referenceFound) { // do we have a reference now? or do we need to dig deeper
-          if (msc_debug_parser_data) file_log("Reference has not been found yet, going fishing\n");
+          if (msc_debug_parser_data) PrintToLog("Reference has not been found yet, going fishing\n");
           BOOST_FOREACH(const string &addr, address_data) {
               if (addr != exodus_address) { // removed strSender restriction, not to spec
                   if ((addr == strSender) && (!changeRemoved)) {
                       changeRemoved = true; // per spec ignore first output to sender as change if multiple possible ref addresses
-                      if (msc_debug_parser_data) file_log("Removed change\n");
+                      if (msc_debug_parser_data) PrintToLog("Removed change\n");
                   } else {
                       strReference = addr; // this may be set several times, but last time will be highest vout
-                      if (msc_debug_parser_data) file_log("Resetting strReference as follows: %s \n ", strReference.c_str());
+                      if (msc_debug_parser_data) PrintToLog("Resetting strReference as follows: %s \n ", strReference);
                   }
               }
           }
       }
-      if (msc_debug_parser_data) file_log("Ending reference identification\nFinal decision on reference identification is: %s\n", strReference.c_str());
-      if (msc_debug_parser) file_log("%s(), line %d, file: %s\n", __FUNCTION__, __LINE__, __FILE__);
+      if (msc_debug_parser_data) PrintToLog("Ending reference identification\nFinal decision on reference identification is: %s\n", strReference);
+      if (msc_debug_parser) PrintToLog("%s(), line %d, file: %s\n", __FUNCTION__, __LINE__, __FILE__);
       // ### CLASS B SPECIFC PARSING ###
       if (omniClass == OMNI_CLASS_B) {
           for (unsigned int k = 0; k<multisig_script_data.size();k++) {
-              if (msc_debug_parser) file_log("%s(), line %d, file: %s\n", __FUNCTION__, __LINE__, __FILE__);
+              if (msc_debug_parser) PrintToLog("%s(), line %d, file: %s\n", __FUNCTION__, __LINE__, __FILE__);
               CPubKey key(ParseHex(multisig_script_data[k]));
               CKeyID keyID = key.GetID();
               string strAddress = CBitcoinAddress(keyID).ToString();
               char *c_addr_type = (char *)"";
               string strPacket;
-              if (msc_debug_parser) file_log("%s(), line %d, file: %s\n", __FUNCTION__, __LINE__, __FILE__);
+              if (msc_debug_parser) PrintToLog("%s(), line %d, file: %s\n", __FUNCTION__, __LINE__, __FILE__);
               vector<unsigned char>hash = ParseHex(strObfuscatedHashes[mdata_count+1]);
               vector<unsigned char>packet = ParseHex(multisig_script_data[k].substr(2*1,2*PACKET_SIZE));
               for (unsigned int i=0;i<packet.size();i++) { // this is a data packet, must deobfuscate now
@@ -1244,16 +1244,16 @@ int parseTransaction(bool bRPConly, const CTransaction &wtx, int nBlock, unsigne
               strPacket = HexStr(packet.begin(),packet.end(), false);
               ++mdata_count;
               if (MAX_PACKETS <= mdata_count) {
-                  file_log("increase MAX_PACKETS ! mdata_count= %d\n", mdata_count);
+                  PrintToLog("increase MAX_PACKETS ! mdata_count= %d\n", mdata_count);
                   return -222;
               }
-              if (msc_debug_parser_data) file_log("multisig_data[%d]:%s: %s%s\n", k, multisig_script_data[k].c_str(), strAddress.c_str(), c_addr_type);
-              if (!strPacket.empty()) { if (msc_debug_parser) file_log("packet #%d: %s\n", mdata_count, strPacket.c_str()); }
-              if (msc_debug_parser) file_log("%s(), line %d, file: %s\n", __FUNCTION__, __LINE__, __FILE__);
+              if (msc_debug_parser_data) PrintToLog("multisig_data[%d]:%s: %s%s\n", k, multisig_script_data[k], strAddress, c_addr_type);
+              if (!strPacket.empty()) { if (msc_debug_parser) PrintToLog("packet #%d: %s\n", mdata_count, strPacket); }
+              if (msc_debug_parser) PrintToLog("%s(), line %d, file: %s\n", __FUNCTION__, __LINE__, __FILE__);
           }
           packet_size = mdata_count * (PACKET_SIZE - 1);
           if (sizeof(single_pkt)<packet_size) return -111;
-          if (msc_debug_parser) file_log("%s(), line %d, file: %s\n", __FUNCTION__, __LINE__, __FILE__);
+          if (msc_debug_parser) PrintToLog("%s(), line %d, file: %s\n", __FUNCTION__, __LINE__, __FILE__);
       }
       // ### CLASS C SPECIFIC PARSING ###
       if (omniClass == OMNI_CLASS_C) {
@@ -1271,17 +1271,17 @@ int parseTransaction(bool bRPConly, const CTransaction &wtx, int nBlock, unsigne
 
   // ### FINALIZE CLASS B ###
   for (int m=0;m<mdata_count;m++) { // now decode mastercoin packets
-      if (msc_debug_parser) file_log("m=%d: %s\n", m, HexStr(packets[m], PACKET_SIZE + packets[m], false).c_str());
+      if (msc_debug_parser) PrintToLog("m=%d: %s\n", m, HexStr(packets[m], PACKET_SIZE + packets[m], false));
       // check to ensure the sequence numbers are sequential and begin with 01 !
       if (1+m != packets[m][0]) {
-          if (msc_debug_spec) file_log("Error: non-sequential seqnum ! expected=%d, got=%d\n", 1+m, packets[m][0]);
+          if (msc_debug_spec) PrintToLog("Error: non-sequential seqnum ! expected=%d, got=%d\n", 1+m, packets[m][0]);
       }
       memcpy(m*(PACKET_SIZE-1)+single_pkt, 1+packets[m], PACKET_SIZE-1); // now ignoring sequence numbers for Class B packets
   }
 
 
   // ### SET MP TX INFO ###
-  if (msc_debug_verbose) file_log("single_pkt: %s\n", HexStr(single_pkt, packet_size + single_pkt, false).c_str());
+  if (msc_debug_verbose) PrintToLog("single_pkt: %s\n", HexStr(single_pkt, packet_size + single_pkt, false));
   mp_tx->Set(strSender, strReference, 0, wtx.GetHash(), nBlock, idx, (unsigned char *)&single_pkt, packet_size, omniClass-1, (inAll-outAll));
   return 0;
 }
@@ -1342,7 +1342,7 @@ static int msc_initial_scan(int nFirstBlock)
     for (nBlock = nFirstBlock; nBlock <= nLastBlock; ++nBlock)
     {
         if (ShutdownRequested()) {
-            file_log("Shutdown requested, stop scan at block %d of %d\n", nBlock, nLastBlock);
+            PrintToLog("Shutdown requested, stop scan at block %d of %d\n", nBlock, nLastBlock);
             break;
         }
 
@@ -1355,7 +1355,7 @@ static int msc_initial_scan(int nFirstBlock)
         if (NULL == pblockindex) break;
         std::string strBlockHash = pblockindex->GetBlockHash().GetHex();
 
-        if (msc_debug_exo) file_log("%s(%d; max=%d):%s, line %d, file: %s\n",
+        if (msc_debug_exo) PrintToLog("%s(%d; max=%d):%s, line %d, file: %s\n",
             __FUNCTION__, nBlock, nLastBlock, strBlockHash, __LINE__, __FILE__);
 
         CBlock block;
@@ -1652,14 +1652,14 @@ static int msc_file_load(const string &filename, int what, bool verifyHash = fal
   if (msc_debug_persistence)
   {
     LogPrintf("Loading %s ... \n", filename);
-    file_log("%s(%s), line %d, file: %s\n", __FUNCTION__, filename.c_str(), __LINE__, __FILE__);
+    PrintToLog("%s(%s), line %d, file: %s\n", __FUNCTION__, filename, __LINE__, __FILE__);
   }
 
   std::ifstream file;
   file.open(filename.c_str());
   if (!file.is_open())
   {
-    if (msc_debug_persistence) LogPrintf("%s(%s): file not found, line %d, file: %s\n", __FUNCTION__, filename.c_str(), __LINE__, __FILE__);
+    if (msc_debug_persistence) LogPrintf("%s(%s): file not found, line %d, file: %s\n", __FUNCTION__, filename, __LINE__, __FILE__);
     return -1;
   }
 
@@ -1706,12 +1706,12 @@ static int msc_file_load(const string &filename, int what, bool verifyHash = fal
     SHA256((unsigned char*)&hash1, sizeof(hash1), (unsigned char*)&hash2);
 
     if (false == boost::iequals(hash2.ToString(), fileHash)) {
-      file_log("File %s loaded, but failed hash validation!\n", filename.c_str());
+      PrintToLog("File %s loaded, but failed hash validation!\n", filename);
       res = -1;
     }
   }
 
-  file_log("%s(%s), loaded lines= %d, res= %d\n", __FUNCTION__, filename.c_str(), lines, res);
+  PrintToLog("%s(%s), loaded lines= %d, res= %d\n", __FUNCTION__, filename, lines, res);
   LogPrintf("%s(): file: %s , loaded lines= %d, res= %d\n", __FUNCTION__, filename, lines, res);
 
   return res;
@@ -2032,7 +2032,7 @@ static void prune_state_files( CBlockIndex const *topIndex )
     std::string fName = dIter->path().empty() ? "<invalid>" : (*--dIter->path().end()).string();
     if (false == boost::filesystem::is_regular_file(dIter->status())) {
       // skip funny business
-      file_log("Non-regular file found in persistence directory : %s\n", fName.c_str());
+      PrintToLog("Non-regular file found in persistence directory : %s\n", fName);
       continue;
     }
 
@@ -2045,7 +2045,7 @@ static void prune_state_files( CBlockIndex const *topIndex )
       blockHash.SetHex(vstr[1]);
       statefulBlockHashes.insert(blockHash);
     } else {
-      file_log("None state file found in persistence directory : %s\n", fName.c_str());
+      PrintToLog("None state file found in persistence directory : %s\n", fName);
     }
   }
 
@@ -2060,9 +2060,9 @@ static void prune_state_files( CBlockIndex const *topIndex )
      if (msc_debug_persistence)
      {
       if (curIndex) {
-        file_log("State from Block:%s is no longer need, removing files (age-from-tip: %d)\n", (*iter).ToString().c_str(), topIndex->nHeight - curIndex->nHeight);
+        PrintToLog("State from Block:%s is no longer need, removing files (age-from-tip: %d)\n", (*iter).ToString(), topIndex->nHeight - curIndex->nHeight);
       } else {
-        file_log("State from Block:%s is no longer need, removing files (not in index)\n", (*iter).ToString().c_str());
+        PrintToLog("State from Block:%s is no longer need, removing files (not in index)\n", (*iter).ToString());
       }
      }
 
@@ -2132,7 +2132,7 @@ int mastercore_init()
   InitDebugLogLevels();
   ShrinkDebugLog();
 
-  file_log("\n%s OMNICORE INIT, build date: " __DATE__ " " __TIME__ "\n\n", DateTimeStrFormat("%Y-%m-%d %H:%M:%S", GetTime()).c_str());
+  PrintToLog("\n%s OMNICORE INIT, build date: " __DATE__ " " __TIME__ "\n\n", DateTimeStrFormat("%Y-%m-%d %H:%M:%S", GetTime()));
 
   if (isNonMainNet())
   {
@@ -2146,12 +2146,12 @@ int mastercore_init()
 
   // check for --autocommit option and set transaction commit flag accordingly
   if (!GetBoolArg("-autocommit", true)) {
-      file_log("Process was started with --autocommit set to false.  Created omni transactions will not be committed to wallet or broadcast.");
+      PrintToLog("Process was started with --autocommit set to false.  Created omni transactions will not be committed to wallet or broadcast.");
       autoCommit = false;
   }
   // check for --startclean option and delete MP_ folders if present
   if (GetBoolArg("-startclean", false)) {
-      file_log("Process was started with --startclean option, attempting to clear persistence files...");
+      PrintToLog("Process was started with --startclean option, attempting to clear persistence files...");
       try
       {
           boost::filesystem::path persistPath = GetDataDir() / "MP_persist";
@@ -2164,11 +2164,11 @@ int mastercore_init()
           if (boost::filesystem::exists(tradePath)) boost::filesystem::remove_all(tradePath);
           if (boost::filesystem::exists(spPath)) boost::filesystem::remove_all(spPath);
           if (boost::filesystem::exists(stoPath)) boost::filesystem::remove_all(stoPath);
-          file_log("Success clearing persistence files (did not raise any exceptions).");
+          PrintToLog("Success clearing persistence files (did not raise any exceptions).");
       }
       catch(boost::filesystem::filesystem_error const & e)
       {
-          file_log("Exception deleting folders for --startclean option.\n");
+          PrintToLog("Exception deleting folders for --startclean option.\n");
           PrintToConsole("Exception deleting folders for --startclean option.\n");
       }
   }
@@ -2257,7 +2257,7 @@ int mastercore_init()
   // collect the real Exodus balances available at the snapshot time
   // redundant? do we need to show it both pre-parse and post-parse?  if so let's label the printfs accordingly
   exodus_balance = getMPbalance(exodus_address, OMNI_PROPERTY_MSC, BALANCE);
-  file_log("[Snapshot] Exodus balance: %s\n", FormatDivisibleMP(exodus_balance));
+  PrintToLog("[Snapshot] Exodus balance: %s\n", FormatDivisibleMP(exodus_balance));
 
   // check out levelDB for the most recently stored alert and load it into global_alert_message then check if expired
   (void) p_txlistdb->setLastAlert(nWaterlineBlock);
@@ -2266,7 +2266,7 @@ int mastercore_init()
 
   // display Exodus balance
   exodus_balance = getMPbalance(exodus_address, OMNI_PROPERTY_MSC, BALANCE);
-  file_log("[Initialized] Exodus balance: %s\n", FormatDivisibleMP(exodus_balance));
+  PrintToLog("[Initialized] Exodus balance: %s\n", FormatDivisibleMP(exodus_balance));
 
   PrintToConsole("Exodus balance: %s MSC\n", FormatDivisibleMP(exodus_balance));
   PrintToConsole("Omni Core initialization completed\n");
@@ -2301,7 +2301,7 @@ int mastercore_shutdown()
         _my_sps = NULL;
     }
 
-    file_log("\n%s OMNICORE SHUTDOWN, build date: " __DATE__ " " __TIME__ "\n\n", DateTimeStrFormat("%Y-%m-%d %H:%M:%S", GetTime()));
+    PrintToLog("\n%s OMNICORE SHUTDOWN, build date: " __DATE__ " " __TIME__ "\n\n", DateTimeStrFormat("%Y-%m-%d %H:%M:%S", GetTime()));
     PrintToConsole("Omni Core shutdown completed\n");
 
     return 0;
@@ -2332,7 +2332,7 @@ int interp_ret = -555555, pop_ret;
   // true MP transaction, validity (such as insufficient funds, or offer not found) is determined elsewhere
 
     interp_ret = mp_obj.interpretPacket();
-    if (interp_ret) file_log("!!! interpretPacket() returned %d !!!\n", interp_ret);
+    if (interp_ret) PrintToLog("!!! interpretPacket() returned %d !!!\n", interp_ret);
 
     // of course only MP-related TXs get recorded
     if (!disableLevelDB)
@@ -2430,9 +2430,9 @@ static int64_t selectCoins(const string &FromAddress, CCoinControl &coinControl,
 
           sAddress = CBitcoinAddress(dest).ToString();
           if (msc_debug_tokens)
-            file_log("%s:IsMine()=%s:IsSpent()=%s:%s: i=%d, nValue= %lu\n",
-                sAddress.c_str(), bIsMine ? "yes" : "NO",
-                bIsSpent ? "YES" : "no", wtxid.ToString().c_str(), i, n);
+            PrintToLog("%s:IsMine()=%s:IsSpent()=%s:%s: i=%d, nValue= %lu\n",
+                sAddress, bIsMine ? "yes" : "NO",
+                bIsSpent ? "YES" : "no", wtxid.ToString(), i, n);
 
           // only use funds from the Sender's address for our MP transaction
           // TODO: may want to a little more selective here, i.e. use smallest possible (~0.1 BTC), but large amounts lead to faster confirmations !
@@ -2505,7 +2505,7 @@ int mastercore::ClassAgnosticWalletTXBuilder(const string &senderAddress, const 
             if (!redemptionAddress.empty()) { address.SetString(redemptionAddress); } else { address.SetString(senderAddress); }
             if (wallet && address.IsValid()) { // validate the redemption address
                 if (address.IsScript()) {
-                    file_log("%s() ERROR: Redemption Address must be specified !\n", __FUNCTION__);
+                    PrintToLog("%s() ERROR: Redemption Address must be specified !\n", __FUNCTION__);
                     return MP_REDEMP_ILLEGAL;
                 } else {
                     CKeyID keyID;
@@ -2544,7 +2544,7 @@ int mastercore::ClassAgnosticWalletTXBuilder(const string &senderAddress, const 
         return 0;
     } else {
         // Commit the transaction to the wallet and broadcast)
-        file_log("%s():%s; nFeeRet = %lu, line %d, file: %s\n", __FUNCTION__, wtxNew.ToString().c_str(), nFeeRet, __LINE__, __FILE__);
+        PrintToLog("%s():%s; nFeeRet = %lu, line %d, file: %s\n", __FUNCTION__, wtxNew.ToString(), nFeeRet, __LINE__, __FILE__);
         if (!wallet->CommitTransaction(wtxNew, reserveKey)) return MP_ERR_COMMIT_TX;
         txid = wtxNew.GetHash();
         return 0;
@@ -2559,13 +2559,12 @@ int CMPTxList::setLastAlert(int blockHeight)
     Iterator* it = NewIterator();
     string lastAlertTxid;
     string lastAlertData;
-    string itData;
     int64_t lastAlertBlock = 0;
     for(it->SeekToFirst(); it->Valid(); it->Next())
     {
        skey = it->key();
        svalue = it->value();
-       string itData = svalue.ToString().c_str();
+       string itData = svalue.ToString();
        std::vector<std::string> vstr;
        boost::split(vstr, itData, boost::is_any_of(":"), token_compress_on);
        // we expect 5 tokens
@@ -2577,8 +2576,8 @@ int CMPTxList::setLastAlert(int blockHeight)
                {
                    if ( (atoi(vstr[1]) > lastAlertBlock) && (atoi(vstr[1]) < blockHeight) ) // is it the most recent and within our parsed range?
                    {
-                      lastAlertTxid = skey.ToString().c_str();
-                      lastAlertData = svalue.ToString().c_str();
+                      lastAlertTxid = skey.ToString();
+                      lastAlertData = svalue.ToString();
                       lastAlertBlock = atoi(vstr[1]);
                    }
                }
@@ -2590,11 +2589,11 @@ int CMPTxList::setLastAlert(int blockHeight)
     // if lastAlertTxid is not empty, load the alert and see if it's still valid - if so, copy to global_alert_message
     if(lastAlertTxid.empty())
     {
-        file_log("DEBUG ALERT No alerts found to load\n");
+        PrintToLog("DEBUG ALERT No alerts found to load\n");
     }
     else
     {
-        file_log("DEBUG ALERT Loading lastAlertTxid %s\n", lastAlertTxid);
+        PrintToLog("DEBUG ALERT Loading lastAlertTxid %s\n", lastAlertTxid);
 
         // reparse lastAlertTxid
         uint256 hash;
@@ -2603,7 +2602,7 @@ int CMPTxList::setLastAlert(int blockHeight)
         uint256 blockHash = 0;
         if (!GetTransaction(hash, wtx, blockHash, true)) //can't find transaction
         {
-            file_log("DEBUG ALERT Unable to load lastAlertTxid, transaction not found\n");
+            PrintToLog("DEBUG ALERT Unable to load lastAlertTxid, transaction not found\n");
         }
         else // note reparsing here is unavoidable because we've only loaded a txid and have no other alert info stored
         {
@@ -2642,12 +2641,12 @@ uint256 CMPTxList::findMetaDExCancel(const uint256 txid)
   {
       skey = it->key();
       svalue = it->value();
-      string svalueStr = svalue.ToString().c_str();
+      string svalueStr = svalue.ToString();
       boost::split(vstr, svalueStr, boost::is_any_of(":"), token_compress_on);
       // obtain the existing affected tx count
       if (3 <= vstr.size())
       {
-          if (vstr[0] == txidStr) { delete it; cancelTxid.SetHex(skey.ToString().c_str()); return cancelTxid; }
+          if (vstr[0] == txidStr) { delete it; cancelTxid.SetHex(skey.ToString()); return cancelTxid; }
       }
   }
 
@@ -2720,7 +2719,7 @@ int CMPTxList::getMPTransactionCountBlock(int block)
         svalue = it->value();
         if (skey.ToString().length() == 64)
         {
-            string strValue = svalue.ToString().c_str();
+            string strValue = svalue.ToString();
             std::vector<std::string> vstr;
             boost::split(vstr, strValue, boost::is_any_of(":"), token_compress_on);
             if (4 == vstr.size())
@@ -2797,11 +2796,11 @@ void CMPTxList::recordMetaDExCancelTX(const uint256 &txidMaster, const uint256 &
        // Step 3 - Create new/update master record for cancel tx in TXList
        const string key = txidMasterStr;
        const string value = strprintf("%u:%d:%u:%lu", fValid ? 1:0, nBlock, type, refNumber);
-       file_log("METADEXCANCELDEBUG : Writing master record %s(%s, valid=%s, block= %d, type= %d, number of affected transactions= %d)\n", __FUNCTION__, txidMaster.ToString().c_str(), fValid ? "YES":"NO", nBlock, type, refNumber);
+       PrintToLog("METADEXCANCELDEBUG : Writing master record %s(%s, valid=%s, block= %d, type= %d, number of affected transactions= %d)\n", __FUNCTION__, txidMaster.ToString(), fValid ? "YES":"NO", nBlock, type, refNumber);
        if (pdb)
        {
            status = pdb->Put(writeoptions, key, value);
-           file_log("METADEXCANCELDEBUG : %s(): %s, line %d, file: %s\n", __FUNCTION__, status.ToString().c_str(), __LINE__, __FILE__);
+           PrintToLog("METADEXCANCELDEBUG : %s(): %s, line %d, file: %s\n", __FUNCTION__, status.ToString(), __LINE__, __FILE__);
        }
 
        // Step 4 - Write sub-record with cancel details
@@ -2809,11 +2808,11 @@ void CMPTxList::recordMetaDExCancelTX(const uint256 &txidMaster, const uint256 &
        const string subKey = STR_REF_SUBKEY_TXID_REF_COMBO(txidStr);
        const string subValue = strprintf("%s:%d:%lu", txidSub.ToString(), propertyId, nValue);
        Status subStatus;
-       file_log("METADEXCANCELDEBUG : Writing sub-record %s with value %s\n", subKey.c_str(), subValue.c_str());
+       PrintToLog("METADEXCANCELDEBUG : Writing sub-record %s with value %s\n", subKey, subValue);
        if (pdb)
        {
            subStatus = pdb->Put(writeoptions, subKey, subValue);
-           file_log("METADEXCANCELDEBUG : %s(): %s, line %d, file: %s\n", __FUNCTION__, subStatus.ToString().c_str(), __LINE__, __FILE__);
+           PrintToLog("METADEXCANCELDEBUG : %s(): %s, line %d, file: %s\n", __FUNCTION__, subStatus.ToString(), __LINE__, __FILE__);
        }
 }
 
@@ -2857,11 +2856,11 @@ void CMPTxList::recordPaymentTX(const uint256 &txid, bool fValid, int nBlock, un
        const string key = txid.ToString();
        const string value = strprintf("%u:%d:%u:%lu", fValid ? 1:0, nBlock, type, numberOfPayments); 
        Status status;
-       file_log("DEXPAYDEBUG : Writing master record %s(%s, valid=%s, block= %d, type= %d, number of payments= %lu)\n", __FUNCTION__, txid.ToString().c_str(), fValid ? "YES":"NO", nBlock, type, numberOfPayments);
+       PrintToLog("DEXPAYDEBUG : Writing master record %s(%s, valid=%s, block= %d, type= %d, number of payments= %lu)\n", __FUNCTION__, txid.ToString(), fValid ? "YES":"NO", nBlock, type, numberOfPayments);
        if (pdb)
        {
            status = pdb->Put(writeoptions, key, value);
-           file_log("DEXPAYDEBUG : %s(): %s, line %d, file: %s\n", __FUNCTION__, status.ToString().c_str(), __LINE__, __FILE__);
+           PrintToLog("DEXPAYDEBUG : %s(): %s, line %d, file: %s\n", __FUNCTION__, status.ToString(), __LINE__, __FILE__);
        }
 
        // Step 4 - Write sub-record with payment details
@@ -2869,11 +2868,11 @@ void CMPTxList::recordPaymentTX(const uint256 &txid, bool fValid, int nBlock, un
        const string subKey = STR_PAYMENT_SUBKEY_TXID_PAYMENT_COMBO(txidStr);
        const string subValue = strprintf("%d:%s:%s:%d:%lu", vout, buyer, seller, propertyId, nValue);
        Status subStatus;
-       file_log("DEXPAYDEBUG : Writing sub-record %s with value %s\n", subKey.c_str(), subValue.c_str());
+       PrintToLog("DEXPAYDEBUG : Writing sub-record %s with value %s\n", subKey, subValue);
        if (pdb)
        {
            subStatus = pdb->Put(writeoptions, subKey, subValue);
-           file_log("DEXPAYDEBUG : %s(): %s, line %d, file: %s\n", __FUNCTION__, subStatus.ToString().c_str(), __LINE__, __FILE__);
+           PrintToLog("DEXPAYDEBUG : %s(): %s, line %d, file: %s\n", __FUNCTION__, subStatus.ToString(), __LINE__, __FILE__);
        }
 }
 
@@ -2883,20 +2882,20 @@ void CMPTxList::recordTX(const uint256 &txid, bool fValid, int nBlock, unsigned 
 
   // overwrite detection, we should never be overwriting a tx, as that means we have redone something a second time
   // reorgs delete all txs from levelDB above reorg_chain_height
-  if (p_txlistdb->exists(txid)) file_log("LEVELDB TX OVERWRITE DETECTION - %s\n", txid.ToString().c_str());
+  if (p_txlistdb->exists(txid)) PrintToLog("LEVELDB TX OVERWRITE DETECTION - %s\n", txid.ToString());
 
 const string key = txid.ToString();
 const string value = strprintf("%u:%d:%u:%lu", fValid ? 1:0, nBlock, type, nValue);
 Status status;
 
-  file_log("%s(%s, valid=%s, block= %d, type= %d, value= %lu)\n",
-   __FUNCTION__, txid.ToString().c_str(), fValid ? "YES":"NO", nBlock, type, nValue);
+  PrintToLog("%s(%s, valid=%s, block= %d, type= %d, value= %lu)\n",
+   __FUNCTION__, txid.ToString(), fValid ? "YES":"NO", nBlock, type, nValue);
 
   if (pdb)
   {
     status = pdb->Put(writeoptions, key, value);
     ++nWritten;
-    if (msc_debug_txdb) file_log("%s(): %s, line %d, file: %s\n", __FUNCTION__, status.ToString().c_str(), __LINE__, __FILE__);
+    if (msc_debug_txdb) PrintToLog("%s(): %s, line %d, file: %s\n", __FUNCTION__, status.ToString(), __LINE__, __FILE__);
   }
 }
 
@@ -2931,7 +2930,7 @@ Status status = pdb->Get(readoptions, txid.ToString(), &value);
 
 void CMPTxList::printStats()
 {
-  file_log("CMPTxList stats: nWritten= %d , nRead= %d\n", nWritten, nRead);
+  PrintToLog("CMPTxList stats: nWritten= %d , nRead= %d\n", nWritten, nRead);
 }
 
 void CMPTxList::printAll()
@@ -2984,7 +2983,7 @@ unsigned int n_found = 0;
       if ((starting_block <= block) && (block <= ending_block))
       {
         ++n_found;
-        file_log("%s() DELETING: %s=%s\n", __FUNCTION__, skey.ToString().c_str(), svalue.ToString().c_str());
+        PrintToLog("%s() DELETING: %s=%s\n", __FUNCTION__, skey.ToString(), svalue.ToString());
         if (bDeleteFound) pdb->Delete(writeoptions, skey);
       }
     }
@@ -3089,7 +3088,7 @@ void CMPSTOList::getRecipients(const uint256 txid, string filterAddress, Array *
                           propertyId = boost::lexical_cast<uint64_t>(svstr[2]);
                       } catch (const boost::bad_lexical_cast &e)
                       {
-                          file_log("DEBUG STO - error in converting values from leveldb\n");
+                          PrintToLog("DEBUG STO - error in converting values from leveldb\n");
                           delete it;
                           return; //(something went wrong)
                       }
@@ -3147,7 +3146,7 @@ void CMPSTOList::recordSTOReceive(string address, const uint256 &txid, int nBloc
           // add details to record
           // see if we are overwriting (check)
           size_t txidMatch = strValue.find(txid.ToString());
-          if(txidMatch!=std::string::npos) file_log("STODEBUG : Duplicating entry for %s : %s\n",address,txid.ToString());
+          if(txidMatch!=std::string::npos) PrintToLog("STODEBUG : Duplicating entry for %s : %s\n",address,txid.ToString());
 
           const string key = address;
           const string newValue = strprintf("%s:%d:%u:%lu,", txid.ToString(), nBlock, propertyId, amount);
@@ -3157,7 +3156,7 @@ void CMPSTOList::recordSTOReceive(string address, const uint256 &txid, int nBloc
           if (pdb)
           {
               status = pdb->Put(writeoptions, key, strValue);
-              file_log("STODBDEBUG : %s(): %s, line %d, file: %s\n", __FUNCTION__, status.ToString().c_str(), __LINE__, __FILE__);
+              PrintToLog("STODBDEBUG : %s(): %s, line %d, file: %s\n", __FUNCTION__, status.ToString(), __LINE__, __FILE__);
           }
       }
   }
@@ -3169,7 +3168,7 @@ void CMPSTOList::recordSTOReceive(string address, const uint256 &txid, int nBloc
       if (pdb)
       {
           status = pdb->Put(writeoptions, key, value);
-          file_log("STODBDEBUG : %s(): %s, line %d, file: %s\n", __FUNCTION__, status.ToString().c_str(), __LINE__, __FILE__);
+          PrintToLog("STODBDEBUG : %s(): %s, line %d, file: %s\n", __FUNCTION__, status.ToString(), __LINE__, __FILE__);
       }
   }
 }
@@ -3193,7 +3192,7 @@ void CMPSTOList::printAll()
 
 void CMPSTOList::printStats()
 {
-  file_log("CMPSTOList stats: tWritten= %d , tRead= %d\n", nWritten, nRead);
+  PrintToLog("CMPSTOList stats: tWritten= %d , tRead= %d\n", nWritten, nRead);
 }
 
 // delete any STO receipts after blockNum
@@ -3233,8 +3232,8 @@ int CMPSTOList::deleteAboveBlock(int blockNum)
         if (pdb)
         {
             status = pdb->Put(writeoptions, key, newValue);
-            file_log("DEBUG STO - rewriting STO data after reorg\n");
-            file_log("STODBDEBUG : %s(): %s, line %d, file: %s\n", __FUNCTION__, status.ToString().c_str(), __LINE__, __FILE__);
+            PrintToLog("DEBUG STO - rewriting STO data after reorg\n");
+            PrintToLog("STODBDEBUG : %s(): %s, line %d, file: %s\n", __FUNCTION__, status.ToString(), __LINE__, __FILE__);
         }
     }
   }
@@ -3347,7 +3346,7 @@ void CMPTradeList::recordTrade(const uint256 txid1, const uint256 txid2, string 
   {
     status = pdb->Put(writeoptions, key, value);
     ++nWritten;
-    if (msc_debug_tradedb) file_log("%s(): %s\n", __FUNCTION__, status.ToString().c_str());
+    if (msc_debug_tradedb) PrintToLog("%s(): %s\n", __FUNCTION__, status.ToString());
   }
 }
 
@@ -3375,7 +3374,7 @@ int CMPTradeList::deleteAboveBlock(int blockNum)
       if (block >= blockNum)
       {
         ++n_found;
-        file_log("%s() DELETING FROM TRADEDB: %s=%s\n", __FUNCTION__, skey.ToString().c_str(), svalue.ToString().c_str());
+        PrintToLog("%s() DELETING FROM TRADEDB: %s=%s\n", __FUNCTION__, skey.ToString(), svalue.ToString());
         pdb->Delete(writeoptions, skey);
       }
     }
@@ -3390,7 +3389,7 @@ int CMPTradeList::deleteAboveBlock(int blockNum)
 
 void CMPTradeList::printStats()
 {
-  file_log("CMPTradeList stats: tWritten= %d , tRead= %d\n", nWritten, nRead);
+  PrintToLog("CMPTradeList stats: tWritten= %d , tRead= %d\n", nWritten, nRead);
 }
 
 int CMPTradeList::getMPTradeCountTotal()
@@ -3417,7 +3416,7 @@ void CMPTradeList::printAll()
     skey = it->key();
     svalue = it->value();
     ++count;
-    PrintToConsole("entry #%8d= %s:%s\n", count, skey.ToString().c_str(), svalue.ToString().c_str());
+    PrintToConsole("entry #%8d= %s:%s\n", count, skey.ToString(), svalue.ToString());
   }
 
   delete it;
@@ -3445,7 +3444,7 @@ bool mastercore::getValidMPTX(const uint256 &txid, int *block, unsigned int *typ
 string result;
 int validity = 0;
 
-  if (msc_debug_txdb) file_log("%s()\n", __FUNCTION__);
+  if (msc_debug_txdb) PrintToLog("%s()\n", __FUNCTION__);
 
   if (!p_txlistdb) return false;
 
@@ -3455,7 +3454,7 @@ int validity = 0;
   std::vector<std::string> vstr;
   boost::split(vstr, result, boost::is_any_of(":"), token_compress_on);
 
-  file_log("%s() size=%lu : %s\n", __FUNCTION__, vstr.size(), result.c_str());
+  PrintToLog("%s() size=%lu : %s\n", __FUNCTION__, vstr.size(), result);
 
   if (1 <= vstr.size()) validity = atoi(vstr[0]);
 
@@ -3544,14 +3543,14 @@ int mastercore_handler_block_end(int nBlockNow, CBlockIndex const * pBlockIndex,
   unsigned int how_many_erased = eraseExpiredAccepts(nBlockNow);
 
   if (how_many_erased)
-    file_log("%s(%d); erased %u accepts this block, line %d, file: %s\n",
+    PrintToLog("%s(%d); erased %u accepts this block, line %d, file: %s\n",
         __FUNCTION__, how_many_erased, nBlockNow, __LINE__, __FILE__);
 
   // calculate devmsc as of this block and update the Exodus' balance
   devmsc = calculate_and_update_devmsc(pBlockIndex->GetBlockTime());
 
   if (msc_debug_exo)
-    file_log("devmsc for block %d: %lu, Exodus balance: %lu\n", nBlockNow,
+    PrintToLog("devmsc for block %d: %lu, Exodus balance: %lu\n", nBlockNow,
         devmsc, getMPbalance(exodus_address, OMNI_PROPERTY_MSC, BALANCE));
 
   // get the total MSC for this wallet, for QT display
@@ -3720,7 +3719,7 @@ std::string new_global_alert_message;
 
         const unsigned int id = _my_sps->putSP(ecosystem, newSP);
         my_crowds.insert(std::make_pair(sender, CMPCrowd(id, nValue, property, deadline, early_bird, percentage, 0, 0)));
-        file_log("CREATED CROWDSALE id: %u value: %lu property: %u\n", id, nValue, property);  
+        PrintToLog("CREATED CROWDSALE id: %u value: %lu property: %u\n", id, nValue, property);  
       }
       rc = 0;
       break;
@@ -3736,7 +3735,7 @@ std::string new_global_alert_message;
         memcpy(&property, &pkt[4], 4);
         swapByteOrder32(property);
 
-        if (msc_debug_sp) file_log("%s() trying to ERASE CROWDSALE for propid= %u=%X\n", __FUNCTION__, property, property);
+        if (msc_debug_sp) PrintToLog("%s() trying to ERASE CROWDSALE for propid= %u=%X\n", __FUNCTION__, property, property);
 
         // ensure we are closing the crowdsale which we opened by checking the property
         if ((it->second).getPropertyId() != property)
@@ -3804,7 +3803,7 @@ std::string new_global_alert_message;
         newSP.manual = true;
 
         const unsigned int id = _my_sps->putSP(ecosystem, newSP);
-        file_log("CREATED MANUAL PROPERTY id: %u admin: %s \n", id, sender.c_str());
+        PrintToLog("CREATED MANUAL PROPERTY id: %u admin: %s \n", id, sender);
       }
       rc = 0;
       break;
@@ -3840,7 +3839,7 @@ std::string new_global_alert_message;
       }
       else
       {
-        file_log("\nPROBLEM writing %s, errno= %d\n", OWNERS_FILENAME, errno);
+        PrintToLog("\nPROBLEM writing %s, errno= %d\n", OWNERS_FILENAME, errno);
       }
 
       rc = logicMath_SendToOwners(fp);
@@ -3937,7 +3936,7 @@ int invalid = 0;  // unused
           CMPSPInfo::Entry sp;
           bool spFound = _my_sps->getSP(crowd->getPropertyId(), sp);
 
-          file_log("INVESTMENT SEND to Crowdsale Issuer: %s\n", receiver.c_str());
+          PrintToLog("INVESTMENT SEND to Crowdsale Issuer: %s\n", receiver);
           
           if (spFound)
           {
@@ -3946,7 +3945,7 @@ int invalid = 0;  // unused
             //pass this in by reference to determine if max_tokens has been reached
             bool close_crowdsale = false; 
             //get txid
-            string sp_txid =  sp.txid.GetHex().c_str();
+            string sp_txid =  sp.txid.GetHex();
 
             //Units going into the calculateFundraiser function must
             //match the unit of the fundraiser's property_type.
@@ -4019,7 +4018,7 @@ int rc = PKT_ERROR_STO -1000;
       // totalTokens will be 0 for non-existing property
       int64_t totalTokens = getTotalTokens(property);
 
-      file_log("\t    Total Tokens: %s\n", FormatMP(property, totalTokens).c_str());
+      PrintToLog("\t    Total Tokens: %s\n", FormatMP(property, totalTokens));
 
       if (0 >= totalTokens)
       {
@@ -4060,7 +4059,7 @@ int rc = PKT_ERROR_STO -1000;
         }
       }
 
-      file_log("  Excluding Sender: %s\n", FormatMP(property, totalTokens).c_str());
+      PrintToLog("  Excluding Sender: %s\n", FormatMP(property, totalTokens));
 
       // determine which property the fee will be paid in
       const unsigned int feeProperty = isTestEcosystemProperty(property) ? OMNI_PROPERTY_TMSC : OMNI_PROPERTY_MSC;
@@ -4110,7 +4109,7 @@ int rc = PKT_ERROR_STO -1000;
 
           if (sent_so_far >= nValue)
           {
-            file_log("SendToOwners: DONE HERE : those who could get paid got paid, SOME DID NOT, but that's ok\n");
+            PrintToLog("SendToOwners: DONE HERE : those who could get paid got paid, SOME DID NOT, but that's ok\n");
             break; // done here, everybody who could get paid got paid
           }
         }
@@ -4120,8 +4119,8 @@ int rc = PKT_ERROR_STO -1000;
           if (will_really_receive > 0) ++n_owners;
 
           if (msc_debug_sto)
-            file_log("%14lu = %s, temp= %38s, should_get= %19lu, will_really_get= %14lu, sent_so_far= %14lu\n",
-            owns, address.c_str(), temp.str(), should_receive, will_really_receive, sent_so_far);
+            PrintToLog("%14lu = %s, temp= %38s, should_get= %19lu, will_really_get= %14lu, sent_so_far= %14lu\n",
+            owns, address, temp.str(), should_receive, will_really_receive, sent_so_far);
 
           // record the detailed info as needed
           if (fhandle) fprintf(fhandle, "%s = %s\n", address.c_str(), FormatMP(property, will_really_receive).c_str());
@@ -4136,10 +4135,10 @@ int rc = PKT_ERROR_STO -1000;
           return (PKT_ERROR_STO -4);
         }
 
-        file_log("\t          Owners: %lu\n", n_owners);
+        PrintToLog("\t          Owners: %lu\n", n_owners);
 
         const int64_t nXferFee = TRANSFER_FEE_PER_OWNER * n_owners;
-        file_log("\t    Transfer fee: %lu.%08lu %s\n", nXferFee/COIN, nXferFee%COIN, strMPProperty(feeProperty).c_str());
+        PrintToLog("\t    Transfer fee: %lu.%08lu %s\n", nXferFee/COIN, nXferFee%COIN, strMPProperty(feeProperty));
 
         // enough coins to pay the fee?
         if (getMPbalance(sender, feeProperty, BALANCE) < nXferFee)
@@ -4167,7 +4166,7 @@ int rc = PKT_ERROR_STO -1000;
       // sent_so_far must equal nValue here
       if (sent_so_far != nValue)
       {
-        file_log("sent_so_far= %14lu, nValue= %14lu, n_owners= %lu\n", sent_so_far, nValue, n_owners);
+        PrintToLog("sent_so_far= %14lu, nValue= %14lu, n_owners= %lu\n", sent_so_far, nValue, n_owners);
 
         // rc = ???
       }

--- a/src/omnicore/omnicore.cpp
+++ b/src/omnicore/omnicore.cpp
@@ -2129,10 +2129,12 @@ int mastercore_init()
 
   PrintToConsole("Initializing Omni Core v%s [%s]\n", OmniCoreVersion(), Params().NetworkIDString());
 
+  PrintToLog("\nInitializing Omni Core v%s [%s]\n", OmniCoreVersion(), Params().NetworkIDString());
+  PrintToLog("Startup time: %s\n", DateTimeStrFormat("%Y-%m-%d %H:%M:%S", GetTime()));
+  PrintToLog("Build date: %s, based on commit: %s\n", BuildDate(), BuildCommit());
+
   InitDebugLogLevels();
   ShrinkDebugLog();
-
-  PrintToLog("\n%s OMNICORE INIT, build date: " __DATE__ " " __TIME__ "\n\n", DateTimeStrFormat("%Y-%m-%d %H:%M:%S", GetTime()));
 
   if (isNonMainNet())
   {
@@ -2146,14 +2148,14 @@ int mastercore_init()
 
   // check for --autocommit option and set transaction commit flag accordingly
   if (!GetBoolArg("-autocommit", true)) {
-      PrintToLog("Process was started with --autocommit set to false.  Created omni transactions will not be committed to wallet or broadcast.");
+      PrintToLog("Process was started with --autocommit set to false. "
+                 "Created Omni transactions will not be committed to wallet or broadcast.\n");
       autoCommit = false;
   }
   // check for --startclean option and delete MP_ folders if present
   if (GetBoolArg("-startclean", false)) {
-      PrintToLog("Process was started with --startclean option, attempting to clear persistence files...");
-      try
-      {
+      PrintToLog("Process was started with --startclean option, attempting to clear persistence files..\n");
+      try {
           boost::filesystem::path persistPath = GetDataDir() / "MP_persist";
           boost::filesystem::path txlistPath = GetDataDir() / "MP_txlist";
           boost::filesystem::path tradePath = GetDataDir() / "MP_tradelist";
@@ -2164,12 +2166,12 @@ int mastercore_init()
           if (boost::filesystem::exists(tradePath)) boost::filesystem::remove_all(tradePath);
           if (boost::filesystem::exists(spPath)) boost::filesystem::remove_all(spPath);
           if (boost::filesystem::exists(stoPath)) boost::filesystem::remove_all(stoPath);
-          PrintToLog("Success clearing persistence files (did not raise any exceptions).");
+          PrintToLog("Success clearing persistence files in datadir %s\n", GetDataDir().string());
       }
-      catch(boost::filesystem::filesystem_error const & e)
+      catch (const boost::filesystem::filesystem_error& e)
       {
-          PrintToLog("Exception deleting folders for --startclean option.\n");
-          PrintToConsole("Exception deleting folders for --startclean option.\n");
+          PrintToLog("Failed to delete persistence folders: %s\n", e.what());
+          PrintToConsole("Failed to delete persistence folders: %s\n", e.what());
       }
   }
   
@@ -2201,8 +2203,12 @@ int mastercore_init()
   if (readPersistence())
   {
     nWaterlineBlock = load_most_relevant_state();
-    PrintToConsole("Loading persistent state: %s\n", nWaterlineBlock>0 ?
-        "OK" : "FAILED (this is normal if this is the first time OmniCore is being run)");
+    if (nWaterlineBlock > 0) {
+        PrintToConsole("Loading persistent state: OK [block %d]\n", nWaterlineBlock);
+    } else {
+        PrintToConsole("Loading persistent state: NONE\n");
+    }
+
     if (nWaterlineBlock < 0) {
       // persistence says we reparse!, nuke some stuff in case the partial loads left stale bits
       clear_all_state();
@@ -2301,7 +2307,9 @@ int mastercore_shutdown()
         _my_sps = NULL;
     }
 
-    PrintToLog("\n%s OMNICORE SHUTDOWN, build date: " __DATE__ " " __TIME__ "\n\n", DateTimeStrFormat("%Y-%m-%d %H:%M:%S", GetTime()));
+    PrintToLog("\nOmni Core shutdown completed\n");
+    PrintToLog("Shutdown time: %s\n", DateTimeStrFormat("%Y-%m-%d %H:%M:%S", GetTime()));
+
     PrintToConsole("Omni Core shutdown completed\n");
 
     return 0;

--- a/src/omnicore/omnicore.cpp
+++ b/src/omnicore/omnicore.cpp
@@ -2129,6 +2129,7 @@ int mastercore_init()
 
   PrintToConsole("Initializing Omni Core v%s [%s]\n", OmniCoreVersion(), Params().NetworkIDString());
 
+  InitDebugLogLevels();
   ShrinkDebugLog();
 
   file_log("\n%s OMNICORE INIT, build date: " __DATE__ " " __TIME__ "\n\n", DateTimeStrFormat("%Y-%m-%d %H:%M:%S", GetTime()).c_str());

--- a/src/omnicore/omnicore.h
+++ b/src/omnicore/omnicore.h
@@ -305,7 +305,7 @@ public:
 
     virtual ~CMPSTOList()
     {
-        if (msc_debug_persistence) file_log("CMPSTOList closed\n");
+        if (msc_debug_persistence) PrintToLog("CMPSTOList closed\n");
     }
 
     void getRecipients(const uint256 txid, string filterAddress, Array *recipientArray, uint64_t *total, uint64_t *stoFee);
@@ -330,7 +330,7 @@ public:
 
     virtual ~CMPTradeList()
     {
-        if (msc_debug_persistence) file_log("CMPTradeList closed\n");
+        if (msc_debug_persistence) PrintToLog("CMPTradeList closed\n");
     }
 
     void recordTrade(const uint256 txid1, const uint256 txid2, string address1, string address2, unsigned int prop1, unsigned int prop2, uint64_t amount1, uint64_t amount2, int blockNum);
@@ -355,7 +355,7 @@ public:
 
     virtual ~CMPTxList()
     {
-        if (msc_debug_persistence) file_log("CMPTxList closed\n");
+        if (msc_debug_persistence) PrintToLog("CMPTxList closed\n");
     }
 
     void recordTX(const uint256 &txid, bool fValid, int nBlock, unsigned int type, uint64_t nValue);

--- a/src/omnicore/pending.cpp
+++ b/src/omnicore/pending.cpp
@@ -70,7 +70,7 @@ void PendingAdd(const uint256& txid, const std::string& sendingAddress, const st
     }
     std::string txDesc = write_string(Value(txobj), true);
     CMPPending pending;
-    if (msc_debug_pending) file_log("%s(%s,%s,%s,%d,%u,%ld,%u,%ld,%d,%s)\n", __FUNCTION__, txid.GetHex(), sendingAddress, refAddress,
+    if (msc_debug_pending) PrintToLog("%s(%s,%s,%s,%d,%u,%ld,%u,%ld,%d,%s)\n", __FUNCTION__, txid.GetHex(), sendingAddress, refAddress,
                                         type, propertyId, amount, propertyIdDesired, amountDesired, action, txDesc);
     if (update_tally_map(sendingAddress, propertyId, -amount, PENDING)) {
         pending.src = sendingAddress;
@@ -93,7 +93,7 @@ void PendingDelete(const uint256& txid)
     if (it != my_pending.end()) {
         CMPPending *p_pending = &(it->second);
         int64_t src_amount = getMPbalance(p_pending->src, p_pending->prop, PENDING);
-        if (msc_debug_pending) file_log("%s(%s): amount=%d\n", __FUNCTION__, txid.GetHex(), src_amount);
+        if (msc_debug_pending) PrintToLog("%s(%s): amount=%d\n", __FUNCTION__, txid.GetHex(), src_amount);
         if (src_amount) update_tally_map(p_pending->src, p_pending->prop, p_pending->amount, PENDING);
         my_pending.erase(it);
     }

--- a/src/omnicore/persistence.cpp
+++ b/src/omnicore/persistence.cpp
@@ -17,11 +17,11 @@
 leveldb::Status CDBBase::Open(const boost::filesystem::path& path, bool fWipe)
 {
     if (fWipe) {
-        if (msc_debug_persistence) file_log("Wiping LevelDB in %s\n", path.string());
+        if (msc_debug_persistence) PrintToLog("Wiping LevelDB in %s\n", path.string());
         leveldb::DestroyDB(path.string(), options);
     }
     TryCreateDirectory(path);
-    if (msc_debug_persistence) file_log("Opening LevelDB in %s\n", path.string());
+    if (msc_debug_persistence) PrintToLog("Opening LevelDB in %s\n", path.string());
 
     return leveldb::DB::Open(options, path.string(), &pdb);
 }
@@ -49,7 +49,7 @@ void CDBBase::Clear()
 
     int64_t nTime = GetTimeMicros() - nTimeStart;
     if (msc_debug_persistence)
-        file_log("Removed %d entries: %s [%.3f ms/entry, %.3f ms total]\n",
+        PrintToLog("Removed %d entries: %s [%.3f ms/entry, %.3f ms total]\n",
             n, status.ToString(), (n > 0 ? (0.001 * nTime / n) : 0), 0.001 * nTime);
 }
 

--- a/src/omnicore/rpc.cpp
+++ b/src/omnicore/rpc.cpp
@@ -154,7 +154,7 @@ int extra2 = 0, extra3 = 0;
   if (1 < params.size()) extra2 = atoi(params[1].get_str());
   if (2 < params.size()) extra3 = atoi(params[2].get_str());
 
-  printf("%s(extra=%d,extra2=%d,extra3=%d)\n", __FUNCTION__, extra, extra2, extra3);
+  PrintToConsole("%s(extra=%d,extra2=%d,extra3=%d)\n", __FUNCTION__, extra, extra2, extra3);
 
   bool bDivisible = isPropertyDivisible(extra2);
 
@@ -171,11 +171,11 @@ int extra2 = 0, extra3 = 0;
           // my_it->first = key
           // my_it->second = value
 
-          printf("%34s => ", (my_it->first).c_str());
+          PrintToConsole("%34s => ", my_it->first);
           total += (my_it->second).print(extra2, bDivisible);
         }
 
-        printf("total for property %d  = %X is %s\n", extra2, extra2, FormatDivisibleMP(total).c_str());
+        PrintToConsole("total for property %d  = %X is %s\n", extra2, extra2, FormatDivisibleMP(total));
       }
       break;
 
@@ -198,15 +198,15 @@ int extra2 = 0, extra3 = 0;
           // my_it->first = key
           // my_it->second = value
 
-          printf("%34s => ", (my_it->first).c_str());
+          PrintToConsole("%34s => ", my_it->first);
           (my_it->second).print(extra2);
 
           (my_it->second).init();
           while (0 != (id = (my_it->second).next()))
           {
-            printf("Id: %u=0x%X ", id, id);
+            PrintToConsole("Id: %u=0x%X ", id, id);
           }
-          printf("\n");
+          PrintToConsole("\n");
         }
       break;
 
@@ -218,7 +218,7 @@ int extra2 = 0, extra3 = 0;
       break;
 
     case 5:
-      printf("isMPinBlockRange(%d,%d)=%s\n", extra2, extra3, isMPinBlockRange(extra2, extra3, false) ? "YES":"NO");
+      PrintToConsole("isMPinBlockRange(%d,%d)=%s\n", extra2, extra3, isMPinBlockRange(extra2, extra3, false) ? "YES":"NO");
       break;
 
     case 6:
@@ -353,7 +353,7 @@ Value getallbalancesforid_MP(const Array& params, bool fHelp)
     {
         unsigned int id;
         bool includeAddress=false;
-        string address = (my_it->first).c_str();
+        string address = my_it->first;
         (my_it->second).init();
         while (0 != (id = (my_it->second).next()))
         {
@@ -625,7 +625,7 @@ Value getcrowdsale_MP(const Array& params, bool fHelp)
         database = sp.historicalData;
     }
 
-    file_log("SIZE OF DB %lu\n", sp.historicalData.size() );
+    PrintToLog("SIZE OF DB %lu\n", sp.historicalData.size() );
     //bool closedEarly = false; //this needs to wait for dead crowdsale persistence
     //int64_t endedTime = 0; //this needs to wait for dead crowdsale persistence
 
@@ -1801,7 +1801,7 @@ Value getinfo_MP(const Array& params, bool fHelp)
             alertResponse.push_back(Pair("alerttype", alertTypeStr));
             alertResponse.push_back(Pair("expiryvalue", FormatIndivisibleMP(expiryValue)));
             if (alertType == 4) { alertResponse.push_back(Pair("typecheck",  FormatIndivisibleMP(typeCheck))); alertResponse.push_back(Pair("vercheck",  FormatIndivisibleMP(verCheck))); }
-            alertResponse.push_back(Pair("alertmessage", alertMessage.c_str()));
+            alertResponse.push_back(Pair("alertmessage", alertMessage));
         }
     }
     infoResponse.push_back(Pair("alert", alertResponse));

--- a/src/omnicore/sp.cpp
+++ b/src/omnicore/sp.cpp
@@ -62,7 +62,7 @@ unsigned int CMPSPInfo::updateSP(unsigned int propertyID, Entry const &info)
     commitBatch.Put(spKey, spValue);
     pdb->Write(syncoptions, &commitBatch);
 
-    file_log("Updated LevelDB with SP data successfully\n");
+    PrintToLog("Updated LevelDB with SP data successfully\n");
     return res;
 }
 
@@ -91,9 +91,9 @@ unsigned int CMPSPInfo::putSP(unsigned char ecosystem, Entry const &info)
     // sanity checking
     string existingEntry;
     if (false == pdb->Get(readoptions, spKey, &existingEntry).IsNotFound() && false == boost::equals(spValue, existingEntry)) {
-      file_log("%s WRITING SP %d TO LEVELDB WHEN A DIFFERENT SP ALREADY EXISTS FOR THAT ID!!!\n", __FUNCTION__, res);
+      PrintToLog("%s WRITING SP %d TO LEVELDB WHEN A DIFFERENT SP ALREADY EXISTS FOR THAT ID!!!\n", __FUNCTION__, res);
     } else if (false == pdb->Get(readoptions, txIndexKey, &existingEntry).IsNotFound() && false == boost::equals(txValue, existingEntry)) {
-      file_log("%s WRITING INDEX TXID %s : SP %d IS OVERWRITING A DIFFERENT VALUE!!!\n", __FUNCTION__, info.txid.ToString(), res);
+      PrintToLog("%s WRITING INDEX TXID %s : SP %d IS OVERWRITING A DIFFERENT VALUE!!!\n", __FUNCTION__, info.txid.ToString(), res);
     }
 
     // atomically write both the the SP and the index to the database
@@ -270,7 +270,7 @@ void mastercore::dumpCrowdsaleInfo(const string &address, CMPCrowd &crowd, bool 
 
   if (!fp)
   {
-    file_log("\nPROBLEM writing %s, errno= %d\n", INFO_FILENAME, errno);
+    PrintToLog("\nPROBLEM writing %s, errno= %d\n", INFO_FILENAME, errno);
     return;
   }
 
@@ -450,7 +450,7 @@ void mastercore::eraseMaxedCrowdsale(const string &address, uint64_t blockTime, 
     if (it != my_crowds.end()) {
 
       CMPCrowd &crowd = it->second;
-      file_log("%s() FOUND MAXED OUT CROWDSALE from address= '%s', erasing...\n", __FUNCTION__, address);
+      PrintToLog("%s() FOUND MAXED OUT CROWDSALE from address= '%s', erasing...\n", __FUNCTION__, address);
 
       dumpCrowdsaleInfo(address, crowd);
 
@@ -486,7 +486,7 @@ CrowdMap::iterator my_it = my_crowds.begin();
 
     if (blockTime > (int64_t)crowd.getDeadline())
     {
-      file_log("%s() FOUND EXPIRED CROWDSALE from address= '%s', erasing...\n", __FUNCTION__, my_it->first);
+      PrintToLog("%s() FOUND EXPIRED CROWDSALE from address= '%s', erasing...\n", __FUNCTION__, my_it->first);
 
       // TODO: dump the info about this crowdsale being delete into a TXT file (JSON perhaps)
       dumpCrowdsaleInfo(my_it->first, my_it->second, true);

--- a/src/omnicore/sp.h
+++ b/src/omnicore/sp.h
@@ -148,7 +148,7 @@ public:
       //Iterate through fundraiser data, serializing it with txid:val:val:val:val;
       bool crowdsale = !fixed && !manual;
       for(it = historicalData.begin(); it != historicalData.end(); it++) {
-         values += it->first.c_str();
+         values += it->first;
          if (crowdsale) {
            values += ":" + boost::lexical_cast<std::string>(it->second.at(0));
            values += ":" + boost::lexical_cast<std::string>(it->second.at(1));
@@ -296,7 +296,7 @@ public:
 
   virtual ~CMPSPInfo()
   {
-    if (msc_debug_persistence) file_log("CMPSPInfo closed\n");
+    if (msc_debug_persistence) PrintToLog("CMPSPInfo closed\n");
   }
 
   void init(unsigned int nextSPID = 0x3UL, unsigned int nextTestSPID = TEST_ECO_PROPERTY_1)

--- a/src/omnicore/tx.cpp
+++ b/src/omnicore/tx.cpp
@@ -33,7 +33,7 @@ int CMPTransaction::step1()
 {
   if (MIN_PAYLOAD_SIZE > pkt_size)  // class C packets could now be as small as 8 bytes
   {
-    file_log("%s() ERROR PACKET TOO SMALL; size = %d, line %d, file: %s\n", __FUNCTION__, pkt_size, __LINE__, __FILE__);
+    PrintToLog("%s() ERROR PACKET TOO SMALL; size = %d, line %d, file: %s\n", __FUNCTION__, pkt_size, __LINE__, __FILE__);
     return -(PKT_ERROR -1);
   }
 
@@ -60,8 +60,8 @@ int CMPTransaction::step1()
           classType = "C";
       break;
   }
-  file_log("\t         version: %d, Class %s\n", version, classType.c_str());
-  file_log("\t            type: %u (%s)\n", type, c_strMasterProtocolTXType(type));
+  PrintToLog("\t         version: %d, Class %s\n", version, classType);
+  PrintToLog("\t            type: %u (%s)\n", type, c_strMasterProtocolTXType(type));
 
   return (type);
 }
@@ -91,7 +91,7 @@ int CMPTransaction::step2_Alert(std::string *new_global_alert_message)
   if(!authorized)
   {
       // not authorized, ignore alert
-      file_log("\t      alert auth: false\n");
+      PrintToLog("\t      alert auth: false\n");
       return (PKT_ERROR -912);
   }
   else
@@ -102,13 +102,13 @@ int CMPTransaction::step2_Alert(std::string *new_global_alert_message)
 
       std::vector<std::string> vstr;
       boost::split(vstr, alertString, boost::is_any_of(":"), token_compress_on);
-      file_log("\t      alert auth: true\n");
-      file_log("\t    alert sender: %s\n", sender);
+      PrintToLog("\t      alert auth: true\n");
+      PrintToLog("\t    alert sender: %s\n", sender);
 
       if (5 != vstr.size())
       {
           // there are not 5 tokens in the alert, badly formed alert and must discard
-          file_log("\t    packet error: badly formed alert != 5 tokens\n");
+          PrintToLog("\t    packet error: badly formed alert != 5 tokens\n");
           return (PKT_ERROR -911);
       }
       else
@@ -126,15 +126,15 @@ int CMPTransaction::step2_Alert(std::string *new_global_alert_message)
               verCheck = boost::lexical_cast<uint32_t>(vstr[3]);
           } catch (const boost::bad_lexical_cast &e)
             {
-                  file_log("DEBUG ALERT - error in converting values from global alert string\n");
+                  PrintToLog("DEBUG ALERT - error in converting values from global alert string\n");
                   return (PKT_ERROR -910); //(something went wrong)
             }
           alertMessage = vstr[4];
-          file_log("\t    message type: %llu\n",alertType);
-          file_log("\t    expiry value: %llu\n",expiryValue);
-          file_log("\t      type check: %llu\n",typeCheck);
-          file_log("\t       ver check: %llu\n",verCheck);
-          file_log("\t   alert message: %s\n", alertMessage);
+          PrintToLog("\t    message type: %llu\n",alertType);
+          PrintToLog("\t    expiry value: %llu\n",expiryValue);
+          PrintToLog("\t      type check: %llu\n",typeCheck);
+          PrintToLog("\t       ver check: %llu\n",verCheck);
+          PrintToLog("\t   alert message: %s\n", alertMessage);
           // copy the alert string into the global_alert_message and return a 0 rc
           string message(alertString);
           *new_global_alert_message=message;
@@ -157,8 +157,8 @@ int CMPTransaction::step2_Value()
   memcpy(&property, &pkt[4], 4);
   swapByteOrder32(property);
 
-  file_log("\t        property: %u (%s)\n", property, strMPProperty(property));
-  file_log("\t           value: %s\n", FormatMP(property, nValue));
+  PrintToLog("\t        property: %u (%s)\n", property, strMPProperty(property));
+  PrintToLog("\t           value: %s\n", FormatMP(property, nValue));
 
   if (MAX_INT_8_BYTES < nValue)
   {
@@ -174,7 +174,7 @@ bool CMPTransaction::isOverrun(const char *p, unsigned int line)
 int now = (char *)p - (char *)&pkt;
 bool bRet = (now > pkt_size);
 
-    if (bRet) file_log("%s(%sline=%u):now= %u, pkt_size= %u\n", __FUNCTION__, bRet ? "OVERRUN !!! ":"", line, now, pkt_size);
+    if (bRet) PrintToLog("%s(%sline=%u):now= %u, pkt_size= %u\n", __FUNCTION__, bRet ? "OVERRUN !!! ":"", line, now, pkt_size);
 
     return bRet;
 }
@@ -192,7 +192,7 @@ unsigned int prop_id;
   error_code = 0;
 
   memcpy(&ecosystem, &pkt[4], 1);
-  file_log("\t       Ecosystem: %u\n", ecosystem);
+  PrintToLog("\t       Ecosystem: %u\n", ecosystem);
 
   // valid values are 1 & 2
   if ((OMNI_PROPERTY_MSC != ecosystem) && (OMNI_PROPERTY_TMSC != ecosystem))
@@ -209,9 +209,9 @@ unsigned int prop_id;
   memcpy(&prev_prop_id, &pkt[7], 4);
   swapByteOrder32(prev_prop_id);
 
-  file_log("\t     Property ID: %u (%s)\n", prop_id, strMPProperty(prop_id));
-  file_log("\t   Property type: %u (%s)\n", prop_type, c_strPropertyType(prop_type));
-  file_log("\tPrev Property ID: %u\n", prev_prop_id);
+  PrintToLog("\t     Property ID: %u (%s)\n", prop_id, strMPProperty(prop_id));
+  PrintToLog("\t   Property type: %u (%s)\n", prop_type, c_strPropertyType(prop_type));
+  PrintToLog("\tPrev Property ID: %u\n", prev_prop_id);
 
   // only 1 & 2 are valid right now
   if ((MSC_PROPERTY_TYPE_INDIVISIBLE != prop_type) && (MSC_PROPERTY_TYPE_DIVISIBLE != prop_type))
@@ -234,11 +234,11 @@ unsigned int prop_id;
   memcpy(url, spstr[i].c_str(), std::min(spstr[i].length(),sizeof(url)-1)); i++;
   memcpy(data, spstr[i].c_str(), std::min(spstr[i].length(),sizeof(data)-1)); i++;
 
-  file_log("\t        Category: %s\n", category);
-  file_log("\t     Subcategory: %s\n", subcategory);
-  file_log("\t            Name: %s\n", name);
-  file_log("\t             URL: %s\n", url);
-  file_log("\t            Data: %s\n", data);
+  PrintToLog("\t        Category: %s\n", category);
+  PrintToLog("\t     Subcategory: %s\n", subcategory);
+  PrintToLog("\t            Name: %s\n", name);
+  PrintToLog("\t             URL: %s\n", url);
+  PrintToLog("\t            Data: %s\n", data);
 
   if (!isTransactionTypeAllowed(block, prop_id, type, version))
   {
@@ -277,13 +277,13 @@ int CMPTransaction::step3_sp_fixed(const char *p)
 
   if (MSC_PROPERTY_TYPE_INDIVISIBLE == prop_type)
   {
-    file_log("\t           value: %lu\n", nValue);
+    PrintToLog("\t           value: %lu\n", nValue);
     if (0 == nValue) return (PKT_ERROR_SP -101);
   }
   else
   if (MSC_PROPERTY_TYPE_DIVISIBLE == prop_type)
   {
-    file_log("\t           value: %lu.%08lu\n", nValue/COIN, nValue%COIN);
+    PrintToLog("\t           value: %lu.%08lu\n", nValue/COIN, nValue%COIN);
     if (0 == nValue) return (PKT_ERROR_SP -102);
   }
 
@@ -305,7 +305,7 @@ int CMPTransaction::step3_sp_variable(const char *p)
   swapByteOrder32(property);
   p += 4;
 
-  file_log("\t        property: %u (%s)\n", property, strMPProperty(property));
+  PrintToLog("\t        property: %u (%s)\n", property, strMPProperty(property));
 
   memcpy(&nValue, p, 8);
   swapByteOrder64(nValue);
@@ -316,13 +316,13 @@ int CMPTransaction::step3_sp_variable(const char *p)
 
   if (MSC_PROPERTY_TYPE_INDIVISIBLE == prop_type)
   {
-    file_log("\t           value: %lu\n", nValue);
+    PrintToLog("\t           value: %lu\n", nValue);
     if (0 == nValue) return (PKT_ERROR_SP -201);
   }
   else
   if (MSC_PROPERTY_TYPE_DIVISIBLE == prop_type)
   {
-    file_log("\t           value: %lu.%08lu\n", nValue/COIN, nValue%COIN);
+    PrintToLog("\t           value: %lu.%08lu\n", nValue/COIN, nValue%COIN);
     if (0 == nValue) return (PKT_ERROR_SP -202);
   }
 
@@ -334,7 +334,7 @@ int CMPTransaction::step3_sp_variable(const char *p)
   memcpy(&deadline, p, 8);
   swapByteOrder64(deadline);
   p += 8;
-  file_log("\t        Deadline: %s (%lX)\n", DateTimeStrFormat("%Y-%m-%d %H:%M:%S", deadline), deadline);
+  PrintToLog("\t        Deadline: %s (%lX)\n", DateTimeStrFormat("%Y-%m-%d %H:%M:%S", deadline), deadline);
 
   if (!deadline) return (PKT_ERROR_SP -203);  // deadline cannot be 0
 
@@ -342,10 +342,10 @@ int CMPTransaction::step3_sp_variable(const char *p)
   if (deadline < (uint64_t)blockTime) return (PKT_ERROR_SP -204);
 
   memcpy(&early_bird, p++, 1);
-  file_log("\tEarly Bird Bonus: %u\n", early_bird);
+  PrintToLog("\tEarly Bird Bonus: %u\n", early_bird);
 
   memcpy(&percentage, p++, 1);
-  file_log("\t      Percentage: %u\n", percentage);
+  PrintToLog("\t      Percentage: %u\n", percentage);
 
   if (isOverrun(p, __LINE__)) return (PKT_ERROR_SP -765);
 
@@ -367,7 +367,7 @@ static const char * const subaction_name[] = { "empty", "new", "update", "cancel
 
       if ((OMNI_PROPERTY_TMSC != property) && (OMNI_PROPERTY_MSC != property))
       {
-        file_log("No smart properties allowed on the DeX...\n");
+        PrintToLog("No smart properties allowed on the DeX...\n");
         return PKT_ERROR_TRADEOFFER -72;
       }
 
@@ -382,10 +382,10 @@ static const char * const subaction_name[] = { "empty", "new", "update", "cancel
       swapByteOrder64(amount_desired);
       swapByteOrder64(min_fee);
 
-    file_log("\t  amount desired: %lu.%08lu\n", amount_desired / COIN, amount_desired % COIN);
-    file_log("\tblock time limit: %u\n", blocktimelimit);
-    file_log("\t         min fee: %lu.%08lu\n", min_fee / COIN, min_fee % COIN);
-    file_log("\t      sub-action: %u (%s)\n", subaction, subaction < sizeof(subaction_name)/sizeof(subaction_name[0]) ? subaction_name[subaction] : "");
+    PrintToLog("\t  amount desired: %lu.%08lu\n", amount_desired / COIN, amount_desired % COIN);
+    PrintToLog("\tblock time limit: %u\n", blocktimelimit);
+    PrintToLog("\t         min fee: %lu.%08lu\n", min_fee / COIN, min_fee % COIN);
+    PrintToLog("\t      sub-action: %u (%s)\n", subaction, subaction < sizeof(subaction_name)/sizeof(subaction_name[0]) ? subaction_name[subaction] : "");
 
       if (obj_o)
       {
@@ -425,7 +425,7 @@ static const char * const subaction_name[] = { "empty", "new", "update", "cancel
           {
             if ((CANCEL != subaction) && (UPDATE != subaction))
             {
-              file_log("%s() INVALID SELL OFFER -- ONE ALREADY EXISTS\n", __FUNCTION__);
+              PrintToLog("%s() INVALID SELL OFFER -- ONE ALREADY EXISTS\n", __FUNCTION__);
               rc = PKT_ERROR_TRADEOFFER -11;
               break;
             }
@@ -435,7 +435,7 @@ static const char * const subaction_name[] = { "empty", "new", "update", "cancel
             // Offer does not exist
             if ((NEW != subaction))
             {
-              file_log("%s() INVALID SELL OFFER -- UPDATE OR CANCEL ACTION WHEN NONE IS POSSIBLE\n", __FUNCTION__);
+              PrintToLog("%s() INVALID SELL OFFER -- UPDATE OR CANCEL ACTION WHEN NONE IS POSSIBLE\n", __FUNCTION__);
               rc = PKT_ERROR_TRADEOFFER -12;
               break;
             }
@@ -491,12 +491,12 @@ int CMPTransaction::logicMath_MetaDEx(CMPMetaDEx *mdex_o)
     memcpy(&desired_value, &pkt[20], 8);
     swapByteOrder64(desired_value);
 
-    file_log("\tdesired property: %u (%s)\n", desired_property, strMPProperty(desired_property));
-    file_log("\t   desired value: %s\n", FormatMP(desired_property, desired_value));
+    PrintToLog("\tdesired property: %u (%s)\n", desired_property, strMPProperty(desired_property));
+    PrintToLog("\t   desired value: %s\n", FormatMP(desired_property, desired_value));
 
     memcpy(&action, &pkt[28], 1);
 
-    file_log("\t          action: %u\n", action);
+    PrintToLog("\t          action: %u\n", action);
 
     if (mdex_o)
     {
@@ -594,18 +594,18 @@ int CMPTransaction::logicMath_GrantTokens()
     int rc = PKT_ERROR_TOKENS - 1000;
 
     if (!isTransactionTypeAllowed(block, property, type, version)) {
-      file_log("\tRejecting Grant: Transaction type not yet allowed\n");
+      PrintToLog("\tRejecting Grant: Transaction type not yet allowed\n");
       return (PKT_ERROR_TOKENS - 22);
     }
 
     if (sender.empty()) {
-      file_log("\tRejecting Grant: Sender is empty\n");
+      PrintToLog("\tRejecting Grant: Sender is empty\n");
       return (PKT_ERROR_TOKENS - 23);
     }
 
     // manual issuance check
     if (false == _my_sps->hasSP(property)) {
-      file_log("\tRejecting Grant: SP id:%u does not exist\n", property);
+      PrintToLog("\tRejecting Grant: SP id:%u does not exist\n", property);
       return (PKT_ERROR_TOKENS - 24);
     }
 
@@ -613,14 +613,14 @@ int CMPTransaction::logicMath_GrantTokens()
     _my_sps->getSP(property, sp);
 
     if (false == sp.manual) {
-      file_log("\tRejecting Grant: SP id:%u was not issued with a TX 54\n", property);
+      PrintToLog("\tRejecting Grant: SP id:%u was not issued with a TX 54\n", property);
       return (PKT_ERROR_TOKENS - 25);
     }
 
 
     // issuer check
     if (false == boost::iequals(sender, sp.issuer)) {
-      file_log("\tRejecting Grant: %s is not the issuer of SP id: %u\n", sender, property);
+      PrintToLog("\tRejecting Grant: %s is not the issuer of SP id: %u\n", sender, property);
       return (PKT_ERROR_TOKENS - 26);
     }
 
@@ -632,7 +632,7 @@ int CMPTransaction::logicMath_GrantTokens()
       } else {
         snprintf(prettyTokens, 256, "%lu", nValue);
       }
-      file_log("\tRejecting Grant: granting %s tokens on SP id:%u would overflow the maximum limit for tokens in a smart property\n", prettyTokens, property);
+      PrintToLog("\tRejecting Grant: granting %s tokens on SP id:%u would overflow the maximum limit for tokens in a smart property\n", prettyTokens, property);
       return (PKT_ERROR_TOKENS - 27);
     }
 
@@ -659,18 +659,18 @@ int CMPTransaction::logicMath_RevokeTokens()
     int rc = PKT_ERROR_TOKENS - 1000;
 
     if (!isTransactionTypeAllowed(block, property, type, version)) {
-      file_log("\tRejecting Revoke: Transaction type not yet allowed\n");
+      PrintToLog("\tRejecting Revoke: Transaction type not yet allowed\n");
       return (PKT_ERROR_TOKENS - 22);
     }
 
     if (sender.empty()) {
-      file_log("\tRejecting Revoke: Sender is empty\n");
+      PrintToLog("\tRejecting Revoke: Sender is empty\n");
       return (PKT_ERROR_TOKENS - 23);
     }
 
     // manual issuance check
     if (false == _my_sps->hasSP(property)) {
-      file_log("\tRejecting Revoke: SP id:%d does not exist\n", property);
+      PrintToLog("\tRejecting Revoke: SP id:%d does not exist\n", property);
       return (PKT_ERROR_TOKENS - 24);
     }
 
@@ -678,13 +678,13 @@ int CMPTransaction::logicMath_RevokeTokens()
     _my_sps->getSP(property, sp);
 
     if (false == sp.manual) {
-      file_log("\tRejecting Revoke: SP id:%d was not issued with a TX 54\n", property);
+      PrintToLog("\tRejecting Revoke: SP id:%d was not issued with a TX 54\n", property);
       return (PKT_ERROR_TOKENS - 25);
     }
 
     // insufficient funds check and revoke
     if (false == update_tally_map(sender, property, -nValue, BALANCE)) {
-      file_log("\tRejecting Revoke: insufficient funds\n");
+      PrintToLog("\tRejecting Revoke: insufficient funds\n");
       return (PKT_ERROR_TOKENS - 111);
     }
 
@@ -706,22 +706,22 @@ int CMPTransaction::logicMath_ChangeIssuer()
   int rc = PKT_ERROR_TOKENS - 1000;
 
   if (!isTransactionTypeAllowed(block, property, type, version)) {
-    file_log("\tRejecting Change of Issuer: Transaction type not yet allowed\n");
+    PrintToLog("\tRejecting Change of Issuer: Transaction type not yet allowed\n");
     return (PKT_ERROR_TOKENS - 22);
   }
 
   if (sender.empty()) {
-    file_log("\tRejecting Change of Issuer: Sender is empty\n");
+    PrintToLog("\tRejecting Change of Issuer: Sender is empty\n");
     return (PKT_ERROR_TOKENS - 23);
   }
 
   if (receiver.empty()) {
-    file_log("\tRejecting Change of Issuer: Receiver is empty\n");
+    PrintToLog("\tRejecting Change of Issuer: Receiver is empty\n");
     return (PKT_ERROR_TOKENS - 23);
   }
 
   if (false == _my_sps->hasSP(property)) {
-    file_log("\tRejecting Change of Issuer: SP id:%d does not exist\n", property);
+    PrintToLog("\tRejecting Change of Issuer: SP id:%d does not exist\n", property);
     return (PKT_ERROR_TOKENS - 24);
   }
 
@@ -730,7 +730,7 @@ int CMPTransaction::logicMath_ChangeIssuer()
 
   // issuer check
   if (false == boost::iequals(sender, sp.issuer)) {
-    file_log("\tRejecting Change of Issuer: %s is not the issuer of SP id:%d\n", sender, property);
+    PrintToLog("\tRejecting Change of Issuer: %s is not the issuer of SP id:%d\n", sender, property);
     return (PKT_ERROR_TOKENS - 26);
   }
 

--- a/src/omnicore/tx.h
+++ b/src/omnicore/tx.h
@@ -201,12 +201,12 @@ public:
 
   void print()
   {
-    file_log("BLOCK: %d =txid: %s =fee: %1.8lf\n", block, txid.GetHex(), (double)tx_fee_paid/(double)COIN);
-    file_log("sender: %s ; receiver: %s\n", sender, receiver);
+    PrintToLog("BLOCK: %d =txid: %s =fee: %1.8lf\n", block, txid.GetHex(), (double)tx_fee_paid/(double)COIN);
+    PrintToLog("sender: %s ; receiver: %s\n", sender, receiver);
 
     if (0<pkt_size)
     {
-      file_log("pkt: %s\n", HexStr(pkt, pkt_size + pkt, false));
+      PrintToLog("pkt: %s\n", HexStr(pkt, pkt_size + pkt, false));
     }
     else
     {

--- a/src/qt/tradehistorydialog.cpp
+++ b/src/qt/tradehistorydialog.cpp
@@ -406,7 +406,7 @@ void TradeHistoryDialog::UpdateData()
         txid.SetHex(ui->tradeHistoryTable->item(row,0)->text().toStdString());
         TradeHistoryMap::iterator hIter = tradeHistoryMap.find(txid);
         if (hIter == tradeHistoryMap.end()) {
-            file_log("UI Error: Transaction %s appears in tradeHistoryTable but cannot be found in tradeHistoryMap.\n", txid.GetHex());
+            PrintToLog("UI Error: Transaction %s appears in tradeHistoryTable but cannot be found in tradeHistoryMap.\n", txid.GetHex());
             continue;
         }
         TradeHistoryObject *tmpObjTH = &(hIter->second);

--- a/src/qt/txhistorydialog.cpp
+++ b/src/qt/txhistorydialog.cpp
@@ -256,7 +256,7 @@ int TXHistoryDialog::PopulateHistoryMap()
                         // STO not in historyMap, get details
                         uint64_t propertyId = 0;
                         try { propertyId = boost::lexical_cast<uint64_t>(svstr[3]); } // attempt to extract propertyId
-                          catch (const boost::bad_lexical_cast &e) { file_log("DEBUG STO - error in converting values from leveldb\n"); continue; } //(something went wrong)
+                          catch (const boost::bad_lexical_cast &e) { PrintToLog("DEBUG STO - error in converting values from leveldb\n"); continue; } //(something went wrong)
                         Array receiveArray;
                         uint64_t total = 0;
                         uint64_t stoFee = 0;


### PR DESCRIPTION
`DebugLogInit()` is only called, if entries are printed to a log file, but not, if `--printtoconsole` is used.

The default debug log filename was changed to `omnicore.log`.

If no user defined path is provided via `--logfile`, then the client's datadir is used as default location, with updated file name `omnicore.log`.

`file_log` was renamed to `PrintToLog()`.

And the persistence information was changed to:

```
Loading persistent state: OK [block 123456]
```

On failure:

```
Loading persistent state: NONE
```

Especially the later is just an idea, but imho it's more "neutral".
