### PR TITLE
Don't notify about Omni events, while waiting

### DIFF
--- a/src/qt/clientmodel.h
+++ b/src/qt/clientmodel.h
@@ -69,6 +69,9 @@ public:
     QString clientName() const;
     QString formatClientStartupTime() const;
 
+    bool tryLockOmniStateChanged();
+    bool tryLockOmniBalanceChanged();
+
 private:
     OptionsModel *optionsModel;
     PeerTableModel *peerTableModel;
@@ -83,6 +86,9 @@ private:
 
     void subscribeToCoreSignals();
     void unsubscribeFromCoreSignals();
+
+    bool lockedOmniStateChanged;
+    bool lockedOmniBalanceChanged;
 
 signals:
     void numConnectionsChanged(int count);


### PR DESCRIPTION
As long as the notification events haven't arrived, no new ones are enqueued.

This prevents the forming of a queue of events, which are going to be superseded anyway.

It resolves https://github.com/OmniLayer/omnicore/issues/65.
