### PR TITLE
Refine handling of pending/completed activations

### DIFF
--- a/qa/pull-tester/omnicore-rpc-tests.sh
+++ b/qa/pull-tester/omnicore-rpc-tests.sh
@@ -16,7 +16,7 @@ touch "$DATADIR/regtest/omnicore.log"
 cd $TESTDIR
 echo "Omni Core RPC test dir: "$TESTDIR
 echo "Last OmniJ commit: "$(git log -n 1 --format="%H Author: %cn <%ce>")
-$REAL_BITCOIND -regtest -txindex -server -daemon -rpcuser=bitcoinrpc -rpcpassword=pass -debug=1 -omnidebug=all -omnialertallowsender=any -discover=0 -listen=0 -datadir="$DATADIR" &
+$REAL_BITCOIND -regtest -txindex -server -daemon -rpcuser=bitcoinrpc -rpcpassword=pass -debug=1 -omnidebug=all -omnialertallowsender=any -omniactivationallowsender=any -discover=0 -listen=0 -datadir="$DATADIR" &
 $REAL_BITCOINCLI -regtest -rpcuser=bitcoinrpc -rpcpassword=pass -rpcwait getinfo
 $REAL_BITCOINCLI -regtest -rpcuser=bitcoinrpc -rpcpassword=pass -rpcwait getinfo_MP
 ./gradlew --console plain :omnij-rpc:regTest

--- a/src/omnicore/activation.cpp
+++ b/src/omnicore/activation.cpp
@@ -112,6 +112,18 @@ std::vector<FeatureActivation> GetCompletedActivations()
 }
 
 /**
+ * Removes all pending or completed activations.
+ *
+ * A signal is fired to notify the UI about the status update.
+ */
+void ClearActivations()
+{
+    vecPendingActivations.clear();
+    vecCompletedActivations.clear();
+    uiInterface.OmniStateChanged();
+}
+
+/**
  * Determines whether the sender is an authorized source for Omni Core feature activation.
  *
  * The option "-omniactivationallowsender=source" can be used to whitelist additional sources,

--- a/src/omnicore/activation.h
+++ b/src/omnicore/activation.h
@@ -9,22 +9,16 @@
 
 namespace mastercore
 {
-
 /** Determines whether the sender is an authorized source for Omni Core activations. */
 bool CheckActivationAuthorization(const std::string& sender);
 /** Returns the vector of pending activations */
 std::vector<FeatureActivation> GetPendingActivations();
 /** Returns the vector of completed activations */
 std::vector<FeatureActivation> GetCompletedActivations();
-/** Moves a feature activation from pending vector to completed vector */
-void PendingActivationCompleted(uint16_t featureId);
 /** Checks if any activations went live in the block */
 void CheckLiveActivations(int blockHeight);
 /** Adds a pending activation */
 void AddPendingActivation(uint16_t featureId, int activationBlock, uint32_t minClientVersion, const std::string& featureName);
-/** Deletes a pending activation */
-void DeletePendingActivation(uint16_t featureId);
-
 }
 
 #endif // OMNICORE_ACTIVATION_H

--- a/src/omnicore/activation.h
+++ b/src/omnicore/activation.h
@@ -25,6 +25,8 @@ bool CheckActivationAuthorization(const std::string& sender);
 std::vector<FeatureActivation> GetPendingActivations();
 /** Returns the vector of completed activations */
 std::vector<FeatureActivation> GetCompletedActivations();
+/** Removes all pending or completed activations. */
+void ClearActivations();
 /** Checks if any activations went live in the block */
 void CheckLiveActivations(int blockHeight);
 /** Adds a pending activation */

--- a/src/omnicore/activation.h
+++ b/src/omnicore/activation.h
@@ -9,6 +9,16 @@
 
 namespace mastercore
 {
+/** A structure to represent a feature activation
+ */
+struct FeatureActivation
+{
+    uint16_t featureId;
+    int activationBlock;
+    uint32_t minClientVersion;
+    std::string featureName;
+};
+
 /** Determines whether the sender is an authorized source for Omni Core activations. */
 bool CheckActivationAuthorization(const std::string& sender);
 /** Returns the vector of pending activations */

--- a/src/omnicore/notifications.cpp
+++ b/src/omnicore/notifications.cpp
@@ -44,6 +44,17 @@ void DeleteAlerts(const std::string& sender)
 }
 
 /**
+ * Removes all active alerts.
+ *
+ * A signal is fired to notify the UI about the status update.
+ */
+void ClearAlerts()
+{
+    currentOmniAlerts.clear();
+    uiInterface.OmniStateChanged();
+}
+
+/**
  * Adds a new alert to the alerts vector
  *
  */

--- a/src/omnicore/notifications.h
+++ b/src/omnicore/notifications.h
@@ -32,19 +32,19 @@ bool CheckAlertAuthorization(const std::string& sender);
 
 /** Deletes previously broadcast alerts from the sender. */
 void DeleteAlerts(const std::string& sender);
+/** Removes all active alerts. */
+void ClearAlerts();
 
 /** Adds a new alert to the alerts vector. */
 void AddAlert(const std::string& sender, uint16_t alertType, uint32_t alertExpiry, const std::string& alertMessage);
 
 /** Alert string including meta data. */
 std::vector<AlertData> GetOmniCoreAlerts();
-
 /** Human readable alert messages. */
 std::vector<std::string> GetOmniCoreAlertMessages();
 
 /** Expires any alerts that need expiring. */
 bool CheckExpiredAlerts(unsigned int curBlock, uint64_t curTime);
-
 }
 
 #endif // OMNICORE_NOTIFICATIONS_H

--- a/src/omnicore/omnicore.cpp
+++ b/src/omnicore/omnicore.cpp
@@ -2558,6 +2558,7 @@ static void clear_all_state()
     metadex.clear();
     my_pending.clear();
     ResetConsensusParams();
+    ClearActivations();
 
     // LevelDB based storage
     _my_sps->Clear();

--- a/src/omnicore/omnicore.cpp
+++ b/src/omnicore/omnicore.cpp
@@ -2559,6 +2559,7 @@ static void clear_all_state()
     my_pending.clear();
     ResetConsensusParams();
     ClearActivations();
+    ClearAlerts();
 
     // LevelDB based storage
     _my_sps->Clear();

--- a/src/omnicore/rules.cpp
+++ b/src/omnicore/rules.cpp
@@ -347,55 +347,37 @@ bool ActivateFeature(uint16_t featureId, int activationBlock, uint32_t minClient
             return false;
     }
 
+    // check whether the feature is already active
+    if (IsFeatureActivated(featureId, transactionBlock)) {
+        PrintToLog("Feature activation of ID %d refused as the feature is already live\n", featureId);
+        return false;
+    }
+
     // check feature is recognized and activation is successful
     std::string featureName;
     bool supported = OMNICORE_VERSION >= minClientVersion;
     switch (featureId) {
         case FEATURE_CLASS_C:
-            if (params.NULLDATA_BLOCK <= transactionBlock) {
-                PrintToLog("Feature activation of ID %d refused as the feature is already live\n", featureId);
-                return false;
-            }
             MutableConsensusParams().NULLDATA_BLOCK = activationBlock;
             featureName = "Class C transaction encoding";
         break;
         case FEATURE_METADEX:
-            if (params.MSC_METADEX_BLOCK <= transactionBlock) {
-                PrintToLog("Feature activation of ID %d refused as the feature is already live\n", featureId);
-                return false;
-            }
             MutableConsensusParams().MSC_METADEX_BLOCK = activationBlock;
             featureName = "Distributed Meta Token Exchange";
         break;
         case FEATURE_BETTING:
-            if (params.MSC_BET_BLOCK <= transactionBlock) {
-                PrintToLog("Feature activation of ID %d refused as the feature is already live\n", featureId);
-                return false;
-            }
             MutableConsensusParams().MSC_BET_BLOCK = activationBlock;
             featureName = "Bet transactions";
         break;
         case FEATURE_GRANTEFFECTS:
-            if (params.GRANTEFFECTS_FEATURE_BLOCK <= transactionBlock) {
-                PrintToLog("Feature activation of ID %d refused as the feature is already live\n", featureId);
-                return false;
-            }
             MutableConsensusParams().GRANTEFFECTS_FEATURE_BLOCK = activationBlock;
             featureName = "Remove grant side effects";
         break;
         case FEATURE_DEXMATH:
-            if (params.DEXMATH_FEATURE_BLOCK <= transactionBlock) {
-                PrintToLog("Feature activation of ID %d refused as the feature is already live\n", featureId);
-                return false;
-            }
             MutableConsensusParams().DEXMATH_FEATURE_BLOCK = activationBlock;
             featureName = "DEx integer math update";
         break;
         case FEATURE_SENDALL:
-            if (params.MSC_SEND_ALL_BLOCK <= transactionBlock) {
-                PrintToLog("Feature activation of ID %d refused as the feature is already live\n", featureId);
-                return false;
-            }
             MutableConsensusParams().MSC_SEND_ALL_BLOCK = activationBlock;
             featureName = "Send All transactions";
         break;

--- a/src/omnicore/rules.cpp
+++ b/src/omnicore/rules.cpp
@@ -386,9 +386,10 @@ bool ActivateFeature(uint16_t featureId, int activationBlock, uint32_t minClient
             supported = false;
         break;
     }
+
     PrintToLog("Feature activation of ID %d processed. %s will be enabled at block %d.\n", featureId, featureName, activationBlock);
-    DeletePendingActivation(featureId); // if this feature id was previously scheduled for activation, delete the stale pending object
     AddPendingActivation(featureId, activationBlock, minClientVersion, featureName);
+
     if (!supported) {
         PrintToLog("WARNING!!! AS OF BLOCK %d THIS CLIENT WILL BE OUT OF CONSENSUS AND WILL AUTOMATICALLY SHUTDOWN.\n", activationBlock);
         std::string alertText = strprintf("Your client must be updated and will shutdown at block %d (unsupported feature %d ('%s') activated)\n",
@@ -396,6 +397,7 @@ bool ActivateFeature(uint16_t featureId, int activationBlock, uint32_t minClient
         AddAlert("omnicore", ALERT_BLOCK_EXPIRY, activationBlock, alertText);
         CAlert::Notify(alertText, true);
     }
+
     return true;
 }
 

--- a/src/omnicore/rules.h
+++ b/src/omnicore/rules.h
@@ -27,16 +27,6 @@ const uint16_t FEATURE_DEXMATH = 5;
 //! Feature identifier to enable Send All transactions
 const uint16_t FEATURE_SENDALL = 6;
 
-/** A structure to represent a feature activation
- */
-struct FeatureActivation
-{
-    uint16_t featureId;
-    int activationBlock;
-    uint32_t minClientVersion;
-    std::string featureName;
-};
-
 /** A structure to represent transaction restrictions.
  */
 struct TransactionRestriction


### PR DESCRIPTION
The primary issue I'm trying to solve is that activation entries were not cleared, if the state is resetted, resulting in wrong information shown in the UI and via `"omni_getactivations"`.
